### PR TITLE
Add rep order data extraction logic for CCLF

### DIFF
--- a/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/dto/RepOrderBillingDTO.java
+++ b/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/dto/RepOrderBillingDTO.java
@@ -1,0 +1,37 @@
+package uk.gov.justice.laa.maat.scheduled.tasks.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RepOrderBillingDTO {
+    private Integer id;
+    private Integer applicantId;
+    private String arrestSummonsNo;
+    private String evidenceFeeLevel;
+    private String supplierAccountCode;
+    private Integer magsCourtId;
+    private String magsCourtOutcome;
+    private LocalDate dateReceived;
+    private LocalDate crownCourtRepOrderDate;
+    private String offenceType;
+    private LocalDate crownCourtWithdrawalDate;
+    private Integer applicantHistoryId;
+    private String caseId;
+    private LocalDate committalDate;
+    private String repOrderStatus;
+    private String appealTypeCode;
+    private String crownCourtOutcome;
+    private LocalDate dateCreated;
+    private String userCreated;
+    private LocalDateTime dateModified;
+    private String userModified;
+    private String caseType;
+}

--- a/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/entity/RepOrderBillingEntity.java
+++ b/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/entity/RepOrderBillingEntity.java
@@ -1,0 +1,89 @@
+package uk.gov.justice.laa.maat.scheduled.tasks.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Data
+@Table(name = "REP_ORDERS", schema = "TOGDATA")
+public class RepOrderBillingEntity {
+
+    @Id
+    @Column(name = "id")
+    private Integer id;
+
+    @Column(name = "APPL_ID")
+    private Integer applicantId;
+
+    @Column(name = "ARREST_SUMMONS_NO")
+    private String arrestSummonsNo;
+
+    @Column(name = "EFEL_FEE_LEVEL")
+    private String evidenceFeeLevel;
+
+    @Column(name = "SUPP_ACCOUNT_CODE")
+    private String supplierAccountCode;
+
+    @Column(name = "MACO_COURT")
+    private String magsCourtId;
+
+    @Column(name = "MCOO_OUTCOME")
+    private String magsCourtOutcome;
+
+    @Column(name = "DATE_RECEIVED")
+    private LocalDate dateReceived;
+
+    @Column(name = "CC_REPORDER_DATE")
+    private LocalDate crownCourtRepOrderDate;
+
+    @Column(name = "OFTY_OFFENCE_TYPE")
+    private String offenceType;
+
+    @Column(name = "CC_WITHDRAWAL_DATE")
+    private LocalDate crownCourtWithdrawalDate;
+
+    @Column(name = "APHI_ID")
+    private Integer applicantHistoryId;
+
+    @Column(name = "CASE_ID")
+    private String caseId;
+
+    @Column(name = "COMMITTAL_DATE")
+    private LocalDate committalDate;
+
+    @Column(name = "RORS_STATUS")
+    private String repOrderStatus;
+
+    @Column(name = "APTY_CODE")
+    private String appealTypeCode;
+
+    @Column(name = "CCOO_OUTCOME")
+    private String crownCourtOutcome;
+
+    @Column(name = "DATE_CREATED")
+    private LocalDate dateCreated;
+
+    @Column(name = "USER_CREATED")
+    private String userCreated;
+
+    @Column(name = "DATE_MODIFIED")
+    private LocalDateTime dateModified;
+
+    @Column(name = "USER_MODIFIED")
+    private String userModified;
+
+    @Column(name = "CATY_CASE_TYPE")
+    private String caseType;
+
+}

--- a/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/mapper/RepOrderBillingMapper.java
+++ b/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/mapper/RepOrderBillingMapper.java
@@ -1,0 +1,41 @@
+package uk.gov.justice.laa.maat.scheduled.tasks.mapper;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.StringUtils;
+import uk.gov.justice.laa.maat.scheduled.tasks.dto.RepOrderBillingDTO;
+import uk.gov.justice.laa.maat.scheduled.tasks.entity.RepOrderBillingEntity;
+
+@Slf4j
+public class RepOrderBillingMapper {
+    private RepOrderBillingMapper() { }
+
+    public static RepOrderBillingDTO mapEntityToDTO(RepOrderBillingEntity repOrderEntity) {
+        Integer magsCourtId = !StringUtils.hasLength(repOrderEntity.getMagsCourtId())
+            ? null : Integer.parseInt(repOrderEntity.getMagsCourtId());
+
+        return RepOrderBillingDTO.builder()
+            .id(repOrderEntity.getId())
+            .applicantId(repOrderEntity.getApplicantId())
+            .arrestSummonsNo(repOrderEntity.getArrestSummonsNo())
+            .evidenceFeeLevel(repOrderEntity.getEvidenceFeeLevel())
+            .supplierAccountCode(repOrderEntity.getSupplierAccountCode())
+            .magsCourtId(magsCourtId)
+            .magsCourtOutcome(repOrderEntity.getMagsCourtOutcome())
+            .dateReceived(repOrderEntity.getDateReceived())
+            .crownCourtRepOrderDate(repOrderEntity.getCrownCourtRepOrderDate())
+            .offenceType(repOrderEntity.getOffenceType())
+            .crownCourtWithdrawalDate(repOrderEntity.getCrownCourtWithdrawalDate())
+            .applicantHistoryId(repOrderEntity.getApplicantHistoryId())
+            .caseId(repOrderEntity.getCaseId())
+            .committalDate(repOrderEntity.getCommittalDate())
+            .repOrderStatus(repOrderEntity.getRepOrderStatus())
+            .appealTypeCode(repOrderEntity.getAppealTypeCode())
+            .crownCourtOutcome(repOrderEntity.getCrownCourtOutcome())
+            .dateCreated(repOrderEntity.getDateCreated())
+            .userCreated(repOrderEntity.getUserCreated())
+            .dateModified(repOrderEntity.getDateModified())
+            .userModified(repOrderEntity.getUserModified())
+            .caseType(repOrderEntity.getCaseType())
+            .build();
+    }
+}

--- a/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/repository/RepOrderBillingRepository.java
+++ b/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/repository/RepOrderBillingRepository.java
@@ -1,0 +1,39 @@
+package uk.gov.justice.laa.maat.scheduled.tasks.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+import uk.gov.justice.laa.maat.scheduled.tasks.entity.RepOrderBillingEntity;
+
+@Repository
+public interface RepOrderBillingRepository extends JpaRepository<RepOrderBillingEntity, Integer> {
+    @Query(value = """
+        SELECT  r.id
+              , r.appl_id
+              , r.arrest_summons_no
+              , r.efel_fee_level
+              , r.supp_account_code
+              , r.maco_court
+              , r.mcoo_outcome
+              , r.date_received
+              , r.cc_reporder_date
+              , r.ofty_offence_type
+              , r.cc_withdrawal_date
+              , r.aphi_id
+              , r.case_id
+              , r.committal_date
+              , r.rors_status
+              , r.apty_code
+              , r.ccoo_outcome
+              , r.date_created
+              , r.user_created
+              , r.date_modified
+              , r.user_modified
+              , r.caty_case_type
+        FROM    TOGDATA.REP_ORDERS r
+        JOIN    TOGDATA.MAAT_REFS_TO_EXTRACT ex
+        ON      r.ID = ex.MAAT_ID
+    """, nativeQuery = true)
+    List<RepOrderBillingEntity> getRepOrdersForBilling();
+}

--- a/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/service/RepOrderBillingService.java
+++ b/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/service/RepOrderBillingService.java
@@ -1,0 +1,32 @@
+package uk.gov.justice.laa.maat.scheduled.tasks.service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.gov.justice.laa.maat.scheduled.tasks.dto.RepOrderBillingDTO;
+import uk.gov.justice.laa.maat.scheduled.tasks.entity.RepOrderBillingEntity;
+import uk.gov.justice.laa.maat.scheduled.tasks.mapper.RepOrderBillingMapper;
+import uk.gov.justice.laa.maat.scheduled.tasks.repository.RepOrderBillingRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RepOrderBillingService {
+
+    private final RepOrderBillingRepository repOrderBillingRepository;
+
+    public List<RepOrderBillingDTO> getRepOrdersForBilling() {
+        List<RepOrderBillingEntity> extractedRepOrders = repOrderBillingRepository.getRepOrdersForBilling();
+
+        if (extractedRepOrders.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return extractedRepOrders.stream()
+            .map(RepOrderBillingMapper::mapEntityToDTO)
+            .collect(Collectors.toList());
+    }
+}

--- a/maat-scheduled-tasks/src/test/java/uk/gov/justice/laa/maat/scheduled/tasks/builder/TestEntityDataBuilder.java
+++ b/maat-scheduled-tasks/src/test/java/uk/gov/justice/laa/maat/scheduled/tasks/builder/TestEntityDataBuilder.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.maat.scheduled.tasks.entity.ApplicantHistoryBillingEntity;
+import uk.gov.justice.laa.maat.scheduled.tasks.entity.RepOrderBillingEntity;
 
 @Component
 public class TestEntityDataBuilder {
@@ -23,6 +24,33 @@ public class TestEntityDataBuilder {
             .userCreated("TEST")
             .dateModified(null)
             .userModified(null)
+            .build();
+    }
+
+    public static RepOrderBillingEntity getPopulatedRepOrderForBilling(Integer id) {
+        return RepOrderBillingEntity.builder()
+            .id(id)
+            .applicantId(123)
+            .arrestSummonsNo("ARREST-5678")
+            .evidenceFeeLevel("LEVEL1")
+            .supplierAccountCode("AB123C")
+            .magsCourtId("34")
+            .magsCourtOutcome("COMMITTED")
+            .dateReceived(LocalDate.of(2025, 6, 10))
+            .crownCourtRepOrderDate(LocalDate.of(2025, 6, 12))
+            .offenceType("BURGLARY")
+            .crownCourtWithdrawalDate(LocalDate.of(2025, 6, 30))
+            .applicantHistoryId(96)
+            .caseId("CASE-123-C")
+            .committalDate(LocalDate.of(2025, 6, 11))
+            .repOrderStatus("CURR")
+            .appealTypeCode("ACN")
+            .crownCourtOutcome("CONVICTED")
+            .dateCreated(LocalDate.of(2025, 6, 20))
+            .userCreated("joe-bloggs")
+            .dateModified(LocalDate.of(2025, 6, 21).atStartOfDay())
+            .userModified("alice-smith")
+            .caseType("EITHER WAY")
             .build();
     }
 }

--- a/maat-scheduled-tasks/src/test/java/uk/gov/justice/laa/maat/scheduled/tasks/builder/TestModelDataBuilder.java
+++ b/maat-scheduled-tasks/src/test/java/uk/gov/justice/laa/maat/scheduled/tasks/builder/TestModelDataBuilder.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.maat.scheduled.tasks.dto.ApplicantHistoryBillingDTO;
+import uk.gov.justice.laa.maat.scheduled.tasks.dto.RepOrderBillingDTO;
 
 @Component
 public class TestModelDataBuilder {
@@ -23,6 +24,33 @@ public class TestModelDataBuilder {
             .userCreated("TEST")
             .dateModified(null)
             .userModified(null)
+            .build();
+    }
+
+    public static RepOrderBillingDTO getRepOrderBillingDTO(Integer id) {
+        return RepOrderBillingDTO.builder()
+            .id(id)
+            .applicantId(123)
+            .arrestSummonsNo("ARREST-5678")
+            .evidenceFeeLevel("LEVEL1")
+            .supplierAccountCode("AB123C")
+            .magsCourtId(34)
+            .magsCourtOutcome("COMMITTED")
+            .dateReceived(LocalDate.of(2025, 6, 10))
+            .crownCourtRepOrderDate(LocalDate.of(2025, 6, 12))
+            .offenceType("BURGLARY")
+            .crownCourtWithdrawalDate(LocalDate.of(2025, 6, 30))
+            .applicantHistoryId(96)
+            .caseId("CASE-123-C")
+            .committalDate(LocalDate.of(2025, 6, 11))
+            .repOrderStatus("CURR")
+            .appealTypeCode("ACN")
+            .crownCourtOutcome("CONVICTED")
+            .dateCreated(LocalDate.of(2025, 6, 20))
+            .userCreated("joe-bloggs")
+            .dateModified(LocalDate.of(2025, 6, 21).atStartOfDay())
+            .userModified("alice-smith")
+            .caseType("EITHER WAY")
             .build();
     }
 }

--- a/maat-scheduled-tasks/src/test/java/uk/gov/justice/laa/maat/scheduled/tasks/mapper/RepOrderBillingMapperTest.java
+++ b/maat-scheduled-tasks/src/test/java/uk/gov/justice/laa/maat/scheduled/tasks/mapper/RepOrderBillingMapperTest.java
@@ -1,0 +1,50 @@
+package uk.gov.justice.laa.maat.scheduled.tasks.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.laa.maat.scheduled.tasks.builder.TestEntityDataBuilder;
+import uk.gov.justice.laa.maat.scheduled.tasks.dto.RepOrderBillingDTO;
+import uk.gov.justice.laa.maat.scheduled.tasks.entity.RepOrderBillingEntity;
+
+@ExtendWith(MockitoExtension.class)
+class RepOrderBillingMapperTest {
+
+    @Test
+    void givenARepOrderEntity_whenMapEntityToDtoIsInvoked_thenDtoIsReturned() {
+        RepOrderBillingDTO expectedRepOrder = RepOrderBillingDTO.builder()
+            .id(123)
+            .applicantId(123)
+            .arrestSummonsNo("ARREST-5678")
+            .evidenceFeeLevel("LEVEL1")
+            .supplierAccountCode("AB123C")
+            .magsCourtId(34)
+            .magsCourtOutcome("COMMITTED")
+            .dateReceived(LocalDate.of(2025, 6, 10))
+            .crownCourtRepOrderDate(LocalDate.of(2025, 6, 12))
+            .offenceType("BURGLARY")
+            .crownCourtWithdrawalDate(LocalDate.of(2025, 6, 30))
+            .applicantHistoryId(96)
+            .caseId("CASE-123-C")
+            .committalDate(LocalDate.of(2025, 6, 11))
+            .repOrderStatus("CURR")
+            .appealTypeCode("ACN")
+            .crownCourtOutcome("CONVICTED")
+            .dateCreated(LocalDate.of(2025, 6, 20))
+            .userCreated("joe-bloggs")
+            .dateModified(LocalDate.of(2025, 6, 21).atStartOfDay())
+            .userModified("alice-smith")
+            .caseType("EITHER WAY")
+            .build();
+
+        RepOrderBillingEntity entity = TestEntityDataBuilder.getPopulatedRepOrderForBilling(123);
+
+        RepOrderBillingDTO actualRepOrder = RepOrderBillingMapper.mapEntityToDTO(entity);
+
+        assertEquals(expectedRepOrder, actualRepOrder);
+    }
+
+}

--- a/maat-scheduled-tasks/src/test/java/uk/gov/justice/laa/maat/scheduled/tasks/service/RepOrderBillingServiceTest.java
+++ b/maat-scheduled-tasks/src/test/java/uk/gov/justice/laa/maat/scheduled/tasks/service/RepOrderBillingServiceTest.java
@@ -1,0 +1,53 @@
+package uk.gov.justice.laa.maat.scheduled.tasks.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.laa.maat.scheduled.tasks.builder.TestEntityDataBuilder;
+import uk.gov.justice.laa.maat.scheduled.tasks.builder.TestModelDataBuilder;
+import uk.gov.justice.laa.maat.scheduled.tasks.dto.RepOrderBillingDTO;
+import uk.gov.justice.laa.maat.scheduled.tasks.repository.RepOrderBillingRepository;
+
+@ExtendWith(MockitoExtension.class)
+class RepOrderBillingServiceTest {
+
+    @Mock
+    private RepOrderBillingRepository repOrderBillingRepository;
+
+    @InjectMocks
+    private RepOrderBillingService repOrderBillingService;
+
+    @Test
+    void givenNoRepOrders_whenGetRepOrdersForBillingIsInvoked_thenEmptyListIsReturned() {
+        when(repOrderBillingRepository.getRepOrdersForBilling()).thenReturn(Collections.emptyList());
+
+        List<RepOrderBillingDTO> repOrders = repOrderBillingService.getRepOrdersForBilling();
+
+        assertEquals(Collections.emptyList(), repOrders);
+    }
+
+    @Test
+    void givenRepOrdersExist_whenGetRepOrdersForBillingIsInvoked_thenRepOrdersAreReturned() {
+        when(repOrderBillingRepository.getRepOrdersForBilling()).thenReturn(List.of(
+            TestEntityDataBuilder.getPopulatedRepOrderForBilling(123),
+            TestEntityDataBuilder.getPopulatedRepOrderForBilling(124)
+        ));
+
+        List<RepOrderBillingDTO> expectedRepOrders = List.of(
+            TestModelDataBuilder.getRepOrderBillingDTO(123),
+            TestModelDataBuilder.getRepOrderBillingDTO(124)
+        );
+
+        List<RepOrderBillingDTO> repOrders = repOrderBillingService.getRepOrdersForBilling();
+
+        assertEquals(2, repOrders.size());
+        assertEquals(expectedRepOrders, repOrders);
+    }
+}


### PR DESCRIPTION
This PR adds rep order data extraction logic for the CCLF data extracts. This logic already exists within the MAAT API ([see related PR](https://github.com/ministryofjustice/laa-maat-court-data-api/pull/1123)), but the decision has been taken to duplicate the logic within this scheduler service for the short-term to get scheduled data extracts up-and-running, with a longer-term view on the logic within MAAT API to be taken later.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4314)

