### PR TITLE
Refactor TrialDataService for pulling all record sheet types

### DIFF
--- a/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/entity/XhibitAppealDataEntity.java
+++ b/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/entity/XhibitAppealDataEntity.java
@@ -1,0 +1,38 @@
+package uk.gov.justice.laa.maat.scheduled.tasks.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Data
+@Table(name = "XHIBIT_APPEAL_DATA", schema = "HUB")
+public class XhibitAppealDataEntity {
+    @Id
+    @Column(name = "ID")
+    @SequenceGenerator(name = "xhibit_appeal_data_gen_seq", sequenceName = "XHIBIT_APPEAL_DATA_SEQ", allocationSize = 1, schema = "HUB")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "xhibit_appeal_data_gen_seq")
+    private Integer id;
+
+    @Column(name = "STATUS")
+    private String status;
+
+    @Column(name = "FILENAME")
+    private String filename;
+
+    @Column(name = "XML_CLOB")
+    @Lob
+    private String data;
+}

--- a/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/repository/XhibitAppealDataRepository.java
+++ b/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/repository/XhibitAppealDataRepository.java
@@ -1,0 +1,8 @@
+package uk.gov.justice.laa.maat.scheduled.tasks.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import uk.gov.justice.laa.maat.scheduled.tasks.entity.XhibitAppealDataEntity;
+
+public interface XhibitAppealDataRepository extends JpaRepository<XhibitAppealDataEntity, Integer> {
+
+}

--- a/maat-scheduled-tasks/src/test/java/uk/gov/justice/laa/maat/scheduled/tasks/service/XhibitDataServiceTest.java
+++ b/maat-scheduled-tasks/src/test/java/uk/gov/justice/laa/maat/scheduled/tasks/service/XhibitDataServiceTest.java
@@ -1,6 +1,5 @@
 package uk.gov.justice.laa.maat.scheduled.tasks.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -45,7 +44,6 @@ import uk.gov.justice.laa.maat.scheduled.tasks.exception.XhibitDataServiceExcept
 import uk.gov.justice.laa.maat.scheduled.tasks.matchers.CopyObjectRequestArgumentMatcher;
 import uk.gov.justice.laa.maat.scheduled.tasks.matchers.DeleteObjectRequestArgumentMatcher;
 import uk.gov.justice.laa.maat.scheduled.tasks.matchers.GetObjectRequestArgumentMatcher;
-import uk.gov.justice.laa.maat.scheduled.tasks.matchers.ListObjectsV2RequestArgumentMatcher;
 import uk.gov.justice.laa.maat.scheduled.tasks.responses.GetRecordSheetsResponse;
 
 @ExtendWith(MockitoExtension.class)


### PR DESCRIPTION
This PR refactors the _TrialDataService_ for pulling all record sheet types to remove what would otherwise be duplicated code.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4327)

