### PR TITLE
Add S3 bucket name back as an environment variable

### DIFF
--- a/helm_deploy/laa-maat-scheduled-tasks/templates/_environment.tpl
+++ b/helm_deploy/laa-maat-scheduled-tasks/templates/_environment.tpl
@@ -83,5 +83,10 @@ env:
         secretKeyRef:
             name: maat-scheduled-tasks-env-variables
             key: DATASOURCE_URL
+  - name: S3_DATA_BUCKET_NAME
+    valueFrom:
+        secretKeyRef:
+            name: maat-scheduled-tasks-env-variables
+            key: AWS_S3_XHIBIT_DATA_BUCKET_NAME
 
 {{- end -}}


### PR DESCRIPTION
This PR re-introduces the S3 bucket name as an environment variables to pods in the cluster. This was [previously removed](https://github.com/ministryofjustice/laa-maat-scheduled-tasks/pull/28) as only the dev bucket was created and secret set, causing a start-up failure for the app in later environments. Now that buckets are created in all environments and secrets set accordingly, this environment variable can be safely re-introduced.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4386)
