### PR TITLE
Disable Xhibit record sheet jobs in prod

### DIFF
--- a/helm_deploy/laa-maat-scheduled-tasks/values-prod.yaml
+++ b/helm_deploy/laa-maat-scheduled-tasks/values-prod.yaml
@@ -75,9 +75,9 @@ maat_batch:
 
 xhibit_batch:
   trial_data_processing:
-    cron_expression: '0 0 0 1 1 *'
+    cron_expression: '-'
   appeal_data_processing:
-    cron_expression: '0 0 0 1 1 *'
+    cron_expression: '-'
 
 logging:
   level: INFO


### PR DESCRIPTION
This PR disables the Xhibit trial and appeal record sheet processing jobs in prod.

