### PR TITLE
[LASB-4385] Update Sentry version as previous wouldn't initialise

### DIFF
--- a/maat-scheduled-tasks/build.gradle
+++ b/maat-scheduled-tasks/build.gradle
@@ -13,7 +13,7 @@ java {
 }
 
 def versions = [
-		sentryVersion			: "8.13.0",
+		sentryVersion			: "8.20.0",
 		ojdbcVersion			: "21.7.0.0",
 		mapstructVersion		: "1.6.3",
 		crimeCommonsClasses		: "4.11.1",


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4385)

For some reason 8.13.0 wasn't initialising at application startup. Upgrading to the latest version has fixed it.