### PR TITLE
Karlb/lasb 4405 customisable s3 page size

### DIFF
--- a/helm_deploy/laa-maat-scheduled-tasks/templates/_environment.tpl
+++ b/helm_deploy/laa-maat-scheduled-tasks/templates/_environment.tpl
@@ -89,6 +89,8 @@ env:
     value: {{ .Values.logging.level }}
   - name: AWS_DEFAULT_REGION
     value: {{ .Values.aws_region }}
+  - name: AWS_S3_PAGE_SIZE
+    value: {{ .Values.xhibitBatch.s3PageSize }}
   - name: AWS_S3_XHIBIT_DATA_BUCKET_NAME
     valueFrom:
         secretKeyRef:

--- a/helm_deploy/laa-maat-scheduled-tasks/values-dev.yaml
+++ b/helm_deploy/laa-maat-scheduled-tasks/values-dev.yaml
@@ -93,3 +93,6 @@ cclfApi:
 ccrApi:
   baseUrl: https://ccr-dev.apps.live.cloud-platform.service.justice.gov.uk/ccr/api/v1
   oauthUrl: https://ccr-dev.auth.eu-west-2.amazoncognito.com/oauth2/token
+
+xhibitBatch:
+  s3PageSize: 1

--- a/helm_deploy/laa-maat-scheduled-tasks/values-prod.yaml
+++ b/helm_deploy/laa-maat-scheduled-tasks/values-prod.yaml
@@ -93,3 +93,6 @@ cclfApi:
 ccrApi:
   baseUrl: https://ccr.apps.live.cloud-platform.service.justice.gov.uk/ccr/api/v1
   oauthUrl: https://ccr-production.auth.eu-west-2.amazoncognito.com/oauth2/token
+
+xhibitBatch:
+  s3PageSize: 1000

--- a/helm_deploy/laa-maat-scheduled-tasks/values-test.yaml
+++ b/helm_deploy/laa-maat-scheduled-tasks/values-test.yaml
@@ -93,3 +93,6 @@ cclfApi:
 ccrApi:
   baseUrl: https://ccr-staging.apps.live.cloud-platform.service.justice.gov.uk/ccr/api/v1
   oauthUrl: https://ccr-staging.auth.eu-west-2.amazoncognito.com/oauth2/token
+
+xhibitBatch:
+  s3PageSize: 1

--- a/helm_deploy/laa-maat-scheduled-tasks/values-uat.yaml
+++ b/helm_deploy/laa-maat-scheduled-tasks/values-uat.yaml
@@ -93,3 +93,6 @@ cclfApi:
 ccrApi:
   baseUrl: https://ccr-uat.apps.live.cloud-platform.service.justice.gov.uk/ccr/api/v1
   oauthUrl: https://ccr-uat.auth.eu-west-2.amazoncognito.com/oauth2/token
+
+xhibitBatch:
+  s3PageSize: 1

--- a/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/config/XhibitConfiguration.java
+++ b/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/config/XhibitConfiguration.java
@@ -24,4 +24,7 @@ public class XhibitConfiguration {
 
     @NotNull
     private final String s3DataBucketName;
+
+    @NotNull
+    private final int s3PageSize;
 }

--- a/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/service/XhibitDataService.java
+++ b/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/service/XhibitDataService.java
@@ -52,6 +52,7 @@ public class XhibitDataService {
         String continuationToken = recordSheetsResponse.getContinuationToken();
         ListObjectsV2Request.Builder listObjectsRequestBuilder = ListObjectsV2Request.builder()
             .bucket(xhibitConfiguration.getS3DataBucketName())
+            .maxKeys(xhibitConfiguration.getS3PageSize())
             .prefix(objectKeyPrefix);
 
         if (continuationToken != null) {

--- a/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/service/XhibitDataService.java
+++ b/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/service/XhibitDataService.java
@@ -53,14 +53,17 @@ public class XhibitDataService {
         ListObjectsV2Request.Builder listObjectsRequestBuilder = ListObjectsV2Request.builder()
             .bucket(xhibitConfiguration.getS3DataBucketName())
             .prefix(objectKeyPrefix);
+
         if (continuationToken != null) {
             listObjectsRequestBuilder.continuationToken(continuationToken);
         }
+
         ListObjectsV2Request listObjectsV2Request = listObjectsRequestBuilder.build();
 
         try {
             ListObjectsV2Response listObjectsResponse = s3Client.listObjectsV2(listObjectsV2Request);
             List<S3Object> contents = listObjectsResponse.contents();
+
             if (contents.isEmpty()) {
                 recordSheetsResponse.allRecordSheetsRetrieved(true);
                 return recordSheetsResponse;
@@ -70,6 +73,7 @@ public class XhibitDataService {
                 String filename = key.substring(objectKeyPrefix.length());
                 XhibitRecordSheetDTOBuilder recordSheetDTOBuilder = XhibitRecordSheetDTO.builder()
                     .filename(filename);
+
                 try {
                     GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                         .bucket(xhibitConfiguration.getS3DataBucketName())
@@ -87,9 +91,11 @@ public class XhibitDataService {
 
             recordSheetsResponse.allRecordSheetsRetrieved(!listObjectsResponse.isTruncated());
             recordSheetsResponse.setContinuationToken(listObjectsResponse.nextContinuationToken());
+
             return recordSheetsResponse;
         } catch (SdkClientException | AwsServiceException ex) {
             log.error("AWS S3 error: {}", ex.getMessage());
+
             throw new XhibitDataServiceException(ex.getMessage());
         }
     }
@@ -132,6 +138,7 @@ public class XhibitDataService {
                 }
 
                 DeleteObjectResponse deleteObjectResponse = s3Client.deleteObject(deleteObjectRequest);
+
                 if (!deleteObjectResponse.sdkHttpResponse().isSuccessful()) {
                     log.warn("Failed to delete record sheet {} with source key {}", filename, deleteObjectRequest.key());
                 }

--- a/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/service/XhibitDataService.java
+++ b/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/service/XhibitDataService.java
@@ -48,7 +48,7 @@ public class XhibitDataService {
         return recordSheetsResponse;
     }
 
-    GetRecordSheetsResponse buildRecordSheetsResponse(GetRecordSheetsResponse recordSheetsResponse, String objectKeyPrefix) {
+    private GetRecordSheetsResponse buildRecordSheetsResponse(GetRecordSheetsResponse recordSheetsResponse, String objectKeyPrefix) {
         String continuationToken = recordSheetsResponse.getContinuationToken();
         ListObjectsV2Request.Builder listObjectsRequestBuilder = ListObjectsV2Request.builder()
             .bucket(xhibitConfiguration.getS3DataBucketName())

--- a/maat-scheduled-tasks/src/main/resources/application.yaml
+++ b/maat-scheduled-tasks/src/main/resources/application.yaml
@@ -75,6 +75,7 @@ xhibit-batch:
   object-key-errored-prefix: "errored"
 
   s3-data-bucket-name: ${AWS_S3_XHIBIT_DATA_BUCKET_NAME}
+  s3-page-size: ${AWS_S3_PAGE_SIZE}
 
 billing:
   cleanup_data_feed_log:

--- a/maat-scheduled-tasks/src/test/java/uk/gov/justice/laa/maat/scheduled/tasks/matchers/ListObjectsV2RequestArgumentMatcher.java
+++ b/maat-scheduled-tasks/src/test/java/uk/gov/justice/laa/maat/scheduled/tasks/matchers/ListObjectsV2RequestArgumentMatcher.java
@@ -12,6 +12,7 @@ public class ListObjectsV2RequestArgumentMatcher implements ArgumentMatcher<List
 
     @Override
     public boolean matches(ListObjectsV2Request listObjectsV2Request) {
-        return continuationToken.equals(listObjectsV2Request.continuationToken());
+        return (continuationToken == null && listObjectsV2Request.continuationToken() == null)
+            || continuationToken.equals(listObjectsV2Request.continuationToken());
     }
 }

--- a/maat-scheduled-tasks/src/test/java/uk/gov/justice/laa/maat/scheduled/tasks/service/XhibitDataServiceTest.java
+++ b/maat-scheduled-tasks/src/test/java/uk/gov/justice/laa/maat/scheduled/tasks/service/XhibitDataServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.laa.maat.scheduled.tasks.service;
 
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,11 +24,13 @@ import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.S3Object;
 import uk.gov.justice.laa.maat.scheduled.tasks.config.XhibitConfiguration;
 import uk.gov.justice.laa.maat.scheduled.tasks.dto.XhibitRecordSheetDTO;
+import uk.gov.justice.laa.maat.scheduled.tasks.entity.XhibitTrialDataEntity;
 import uk.gov.justice.laa.maat.scheduled.tasks.enums.RecordSheetType;
 import uk.gov.justice.laa.maat.scheduled.tasks.exception.XhibitDataServiceException;
 import uk.gov.justice.laa.maat.scheduled.tasks.matchers.CopyObjectRequestArgumentMatcher;
 import uk.gov.justice.laa.maat.scheduled.tasks.matchers.DeleteObjectRequestArgumentMatcher;
 import uk.gov.justice.laa.maat.scheduled.tasks.matchers.GetObjectRequestArgumentMatcher;
+import uk.gov.justice.laa.maat.scheduled.tasks.matchers.ListObjectsV2RequestArgumentMatcher;
 import uk.gov.justice.laa.maat.scheduled.tasks.responses.GetRecordSheetsResponse;
 
 import java.nio.charset.StandardCharsets;
@@ -37,6 +40,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -46,11 +50,14 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.justice.laa.maat.scheduled.tasks.service.TrialDataService.OUTPUT_PARAMS;
+import static uk.gov.justice.laa.maat.scheduled.tasks.service.TrialDataService.TRIAL_DATA_TO_MAAT_PROCEDURE;
 
 @ExtendWith(MockitoExtension.class)
 class XhibitDataServiceTest {
 
     private static final String OBJECT_PREFIX = "trial/";
+
     @Mock
     private S3Client s3Client;
 
@@ -79,25 +86,28 @@ class XhibitDataServiceTest {
         lenient().when(xhibitConfiguration.getObjectKeyProcessedPrefix()).thenReturn("processed");
         lenient().when(xhibitConfiguration.getObjectKeyErroredPrefix()).thenReturn("errored");
         lenient().when(xhibitConfiguration.getS3DataBucketName()).thenReturn("bucket");
+        lenient().when(xhibitConfiguration.getS3PageSize()).thenReturn(1);
     }
 
     @Test
-    void buildRecordSheets_Response_whenNoDataFound_thenReturnsEmptyList() {
+    void givenNoRecordSheetsExist_whenGetRecordSheetsResponseIsInvoked_thenNoRecordSheetsReturned() {
         when(listObjectsV2Response.contents()).thenReturn(Collections.emptyList());
         when(s3Client.listObjectsV2(ArgumentMatchers.any(ListObjectsV2Request.class))).thenReturn(listObjectsV2Response);
 
-        GetRecordSheetsResponse recordSheetsResponse = xhibitDataService.buildRecordSheetsResponse(new GetRecordSheetsResponse(), OBJECT_PREFIX);
+        GetRecordSheetsResponse recordSheetsResponse = xhibitDataService.getAllRecordSheets(RecordSheetType.TRIAL);
 
         assertTrue(recordSheetsResponse.getRetrievedRecordSheets().isEmpty());
+        assertTrue(recordSheetsResponse.getErroredRecordSheets().isEmpty());
+        assertTrue(recordSheetsResponse.allRecordSheetsRetrieved());
     }
 
     @Test
-    void buildRecordSheets_whenDataFound_thenReturnsRecordSheetsResponse() {
+    void givenRecordSheetsExist_whenGetRecordSheetsResponseIsInvoked_thenRecordSheetsAreReturned() {
         when(listObjectsV2Response.contents()).thenReturn(List.of(
             S3Object.builder().key("trial/file1.xml").build(),
             S3Object.builder().key("trial/file2.xml").build()
         ));
-        when(listObjectsV2Response.isTruncated()).thenReturn(true);
+        when(listObjectsV2Response.isTruncated()).thenReturn(false);
         when(listObjectsV2Response.nextContinuationToken()).thenReturn(null);
         when(s3Client.listObjectsV2(ArgumentMatchers.any(ListObjectsV2Request.class))).thenReturn(listObjectsV2Response);
 
@@ -106,19 +116,19 @@ class XhibitDataServiceTest {
         setupFileResponse(xhibitRecordSheet1, "trial/file1.xml");
         setupFileResponse(xhibitRecordSheet2, "trial/file2.xml");
 
-        GetRecordSheetsResponse recordSheetsResponse = xhibitDataService.buildRecordSheetsResponse(new GetRecordSheetsResponse(), OBJECT_PREFIX);
+        GetRecordSheetsResponse recordSheetsResponse = xhibitDataService.getAllRecordSheets(RecordSheetType.TRIAL);
 
         assertEquals(expectedRecordSheets, recordSheetsResponse.getRetrievedRecordSheets());
     }
 
     @Test
-    void buildRecordSheets_returnsErroredRecordSheets_Response_whenDataCannotBeRetrieved() {
+    void givenRecordSheetsExistThatCannotBeRetrieved_whenGetRecordSheetsResponseIsInvoked_thenPartialRecordSheetsReturned() {
         when(listObjectsV2Response.contents()).thenReturn(List.of(
             S3Object.builder().key("trial/file1.xml").build(),
             S3Object.builder().key("trial/file2.xml").build(),
             S3Object.builder().key("trial/file3.xml").build()
         ));
-        when(listObjectsV2Response.isTruncated()).thenReturn(true);
+        when(listObjectsV2Response.isTruncated()).thenReturn(false);
         when(listObjectsV2Response.nextContinuationToken()).thenReturn(null);
         when(s3Client.listObjectsV2(ArgumentMatchers.any(ListObjectsV2Request.class))).thenReturn(listObjectsV2Response);
 
@@ -129,7 +139,7 @@ class XhibitDataServiceTest {
         setupFileResponse(xhibitRecordSheet2, "trial/file2.xml");
         setupErrorFileResponse("trial/file3.xml");
 
-        GetRecordSheetsResponse recordSheetsResponse = xhibitDataService.buildRecordSheetsResponse(new GetRecordSheetsResponse(), OBJECT_PREFIX);
+        GetRecordSheetsResponse recordSheetsResponse = xhibitDataService.getAllRecordSheets(RecordSheetType.TRIAL);
 
         assertEquals(expectedSuccessfulRecordSheets, recordSheetsResponse.getRetrievedRecordSheets());
         assertEquals(expectedErroredRecordSheets, recordSheetsResponse.getErroredRecordSheets().stream().map(
@@ -137,10 +147,42 @@ class XhibitDataServiceTest {
     }
 
     @Test
-    void buildRecordSheets_Response_throwsException_whenUnhandledAwsExceptionOccurs() {
+    void givenUnhandledAwsExceptionThrown_whenGetRecordSheetsResponseIsInvoked_thenXhibitDataServiceExceptionIsThrown() {
         doThrow(SdkClientException.class).when(s3Client).listObjectsV2(ArgumentMatchers.any(ListObjectsV2Request.class));
 
-        assertThrows(XhibitDataServiceException.class, () -> xhibitDataService.buildRecordSheetsResponse(new GetRecordSheetsResponse(), OBJECT_PREFIX));
+        assertThrows(XhibitDataServiceException.class, () -> xhibitDataService.getAllRecordSheets(RecordSheetType.TRIAL));
+    }
+
+    @Test
+    void givenMultiplePagesOfRecordSheets_whenGetRecordSheetsResponseIsInvoked_thenAllRecordSheetsReturned() {
+        ListObjectsV2Response firstResponse = ListObjectsV2Response.builder()
+            .contents(List.of(S3Object.builder().key("trial/file1.xml").build()))
+            .isTruncated(true)
+            .nextContinuationToken("test-continuation-token")
+            .build();
+
+        ListObjectsV2Response secondResponse = ListObjectsV2Response.builder()
+            .contents(List.of(S3Object.builder().key("trial/file2.xml").build()))
+            .isTruncated(false)
+            .nextContinuationToken(null)
+            .build();
+
+        doReturn(firstResponse).when(s3Client).listObjectsV2(argThat(new ListObjectsV2RequestArgumentMatcher(null)));
+        doReturn(secondResponse).when(s3Client).listObjectsV2(argThat(new ListObjectsV2RequestArgumentMatcher("test-continuation-token")));
+
+        List<XhibitRecordSheetDTO> expectedSuccessfulRecordSheets = List.of(xhibitRecordSheet2);
+        List<String> expectedErroredRecordSheets = List.of("file1.xml");
+
+        setupErrorFileResponse("trial/file1.xml");
+        setupFileResponse(xhibitRecordSheet2, "trial/file2.xml");
+
+        GetRecordSheetsResponse recordSheetsResponse = xhibitDataService.getAllRecordSheets(RecordSheetType.TRIAL);
+
+        assertEquals(expectedSuccessfulRecordSheets, recordSheetsResponse.getRetrievedRecordSheets());
+        assertEquals(expectedErroredRecordSheets, recordSheetsResponse.getErroredRecordSheets().stream().map(
+            XhibitRecordSheetDTO::getFilename).toList());
+
+        verify(s3Client, times(2)).listObjectsV2(ArgumentMatchers.any(ListObjectsV2Request.class));
     }
 
     @Test

--- a/maat-scheduled-tasks/src/test/resources/application.yaml
+++ b/maat-scheduled-tasks/src/test/resources/application.yaml
@@ -52,6 +52,8 @@ xhibit-batch:
   appeal_data_processing:
     cron_expression: 0 0 9 * * *
 
+  s3-page-size: 1
+
 billing:
   cleanup_data_feed_log:
     cron_expression: 0 0 9 * * *


### PR DESCRIPTION
This PR makes the following changes:

- `s3PageSize` is added as an environment-specific application variable, defined in each of the env files. This will aid in testing of pagination of objects in S3, avoiding the need to create large volumes of test data to be able to run manual integration tests.
- A missing test for the _XhibitDataService_ getAllRecordSheets` method is added. Pagination was previously handled within the _TrialDataService_, but in a recent commit the pagination logic was moved back down the stack and into the_XhibitDataService_. At the same time, tests for the _TrialDataService_ and _AppealDataService_ assumed what the
_GetRecordSheetsResponse_ would like look but without this being tested.
- The `buildRecordSheetsResponse` method in the _XhibitDataService_ is refactored to once again be `private`,
as it should only _ever_ be called through the `getAllRecordSheets` method and therefore does not need exposing.
- Finally, this PR adds sensible line breaks back into the _XhibitDataService_ to aid readability.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4405)
