### PR TITLE
LASB-4404: Improve stored procedure error handling

### DIFF
--- a/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/helper/StoredProcedureParameter.java
+++ b/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/helper/StoredProcedureParameter.java
@@ -1,0 +1,32 @@
+package uk.gov.justice.laa.maat.scheduled.tasks.helper;
+
+import jakarta.persistence.ParameterMode;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public final class StoredProcedureParameter<T> {
+    private final String name;
+    private final Class<T> type;
+    private final T value;
+    private final ParameterMode mode;
+
+    public static <T> StoredProcedureParameter<T> inputParameter(String name, T value) {
+        @SuppressWarnings("unchecked")
+        Class<T> type = (Class<T>) value.getClass();
+        return new StoredProcedureParameter<>(name, type, value, ParameterMode.IN);
+    }
+
+    public static <T> StoredProcedureParameter<T> outputParameter(String name, Class<T> type) {
+        return new StoredProcedureParameter<>(name, type, null, ParameterMode.OUT);
+    }
+
+    public static <T> StoredProcedureParameter<T> inOutParameter(String name, T value) {
+        @SuppressWarnings("unchecked")
+        Class<T> type = (Class<T>) value.getClass();
+        return new StoredProcedureParameter<>(name, type, value, ParameterMode.INOUT);
+    }
+}
+

--- a/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/service/AppealDataService.java
+++ b/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/service/AppealDataService.java
@@ -7,18 +7,27 @@ import org.springframework.transaction.annotation.Transactional;
 import uk.gov.justice.laa.maat.scheduled.tasks.dto.XhibitRecordSheetDTO;
 import uk.gov.justice.laa.maat.scheduled.tasks.entity.XhibitAppealDataEntity;
 import uk.gov.justice.laa.maat.scheduled.tasks.enums.RecordSheetType;
+import uk.gov.justice.laa.maat.scheduled.tasks.exception.StoredProcedureException;
+import uk.gov.justice.laa.maat.scheduled.tasks.helper.StoredProcedureParameter;
 import uk.gov.justice.laa.maat.scheduled.tasks.repository.XhibitAppealDataRepository;
 import uk.gov.justice.laa.maat.scheduled.tasks.responses.GetRecordSheetsResponse;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
-import java.util.Map;
+
+import static uk.gov.justice.laa.maat.scheduled.tasks.helper.StoredProcedureParameter.inputParameter;
+import static uk.gov.justice.laa.maat.scheduled.tasks.helper.StoredProcedureParameter.outputParameter;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class AppealDataService {
 
-    static final Map<String, Class<?>> OUTPUT_PARAMS = Map.of("p_error_code", String.class, "p_err_msg", String.class);
+    static final Collection<StoredProcedureParameter<?>> OUTPUT_PARAMETERS = List.of(
+        outputParameter("p_error_code", String.class),
+        outputParameter("p_err_msg", String.class)
+    );
     static final String APPEAL_DATA_TO_MAAT_PROCEDURE = "hub.xhibit_file_load.process_appeal_record";
 
     private final XhibitDataService xhibitDataService;
@@ -33,7 +42,8 @@ public class AppealDataService {
 
         List<XhibitRecordSheetDTO> erroredRecordSheets = recordSheetsResponse.getErroredRecordSheets();
         if (!erroredRecordSheets.isEmpty()) {
-            xhibitDataService.markRecordSheetsAsErrored(erroredRecordSheets, recordSheetType);
+            List<String> filenames = erroredRecordSheets.stream().map(XhibitRecordSheetDTO::getFilename).toList();
+            xhibitDataService.markRecordSheetsAsErrored(filenames, recordSheetType);
             log.info("Marked errored record sheets { records: {} }.", erroredRecordSheets.size());
         }
 
@@ -52,14 +62,33 @@ public class AppealDataService {
             return;
         }
 
+        List<String> successfulProcedureFilenames = new ArrayList<>();
+        List<String> failedProcedureFilenames = new ArrayList<>();
         for (XhibitAppealDataEntity record : toProcess) {
-            Map<String, Object> inputParams = Map.of("id", record.getId());
-            storedProcedureService.callStoredProcedure(APPEAL_DATA_TO_MAAT_PROCEDURE, inputParams, OUTPUT_PARAMS);
+            Collection<StoredProcedureParameter<?>> parameters = getProcedureParameters(record);
+            try {
+                storedProcedureService.callStoredProcedure(APPEAL_DATA_TO_MAAT_PROCEDURE, parameters);
+                successfulProcedureFilenames.add(record.getFilename());
+            } catch (StoredProcedureException e) {
+                failedProcedureFilenames.add(record.getFilename());
+            }
         }
-        log.info("Processed appeal data in to MAAT. { records: {} }", toProcess.size());
 
-        xhibitDataService.markRecordSheetsAsProcessed(recordSheets, recordSheetType);
+        if (!failedProcedureFilenames.isEmpty()) {
+            xhibitDataService.markRecordSheetsAsErrored(failedProcedureFilenames, recordSheetType);
+            log.info("Marked errored record sheets from failed stored procedure { records: {} }.", failedProcedureFilenames.size());
+        }
+
+        log.info("Processed appeal data in to MAAT. { records: {} }", successfulProcedureFilenames.size());
+
+        xhibitDataService.markRecordSheetsAsProcessed(successfulProcedureFilenames, recordSheetType);
         log.info("Marked appeal record sheets as processed.");
+    }
+
+    private static Collection<StoredProcedureParameter<?>> getProcedureParameters(XhibitAppealDataEntity record) {
+        Collection<StoredProcedureParameter<?>> parameters = new ArrayList<>(OUTPUT_PARAMETERS);
+        parameters.add(inputParameter("id", record.getId()));
+        return parameters;
     }
 
     private void saveRecordSheets(List<XhibitRecordSheetDTO> recordSheets) {

--- a/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/service/TrialDataService.java
+++ b/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/service/TrialDataService.java
@@ -7,18 +7,27 @@ import org.springframework.transaction.annotation.Transactional;
 import uk.gov.justice.laa.maat.scheduled.tasks.dto.XhibitRecordSheetDTO;
 import uk.gov.justice.laa.maat.scheduled.tasks.entity.XhibitTrialDataEntity;
 import uk.gov.justice.laa.maat.scheduled.tasks.enums.RecordSheetType;
+import uk.gov.justice.laa.maat.scheduled.tasks.exception.StoredProcedureException;
+import uk.gov.justice.laa.maat.scheduled.tasks.helper.StoredProcedureParameter;
 import uk.gov.justice.laa.maat.scheduled.tasks.repository.XhibitTrialDataRepository;
 import uk.gov.justice.laa.maat.scheduled.tasks.responses.GetRecordSheetsResponse;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
-import java.util.Map;
+
+import static uk.gov.justice.laa.maat.scheduled.tasks.helper.StoredProcedureParameter.inputParameter;
+import static uk.gov.justice.laa.maat.scheduled.tasks.helper.StoredProcedureParameter.outputParameter;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class TrialDataService {
 
-    static final Map<String, Class<?>> OUTPUT_PARAMS = Map.of("p_error_code", String.class, "p_err_msg", String.class);
+    static final Collection<StoredProcedureParameter<?>> OUTPUT_PARAMETERS = List.of(
+        outputParameter("p_error_code", String.class),
+        outputParameter("p_err_msg", String.class)
+    );
     static final String TRIAL_DATA_TO_MAAT_PROCEDURE = "hub.xhibit_file_load.process_trial_record";
 
     private final XhibitDataService xhibitDataService;
@@ -33,7 +42,8 @@ public class TrialDataService {
 
         List<XhibitRecordSheetDTO> erroredRecordSheets = recordSheetsResponse.getErroredRecordSheets();
         if (!erroredRecordSheets.isEmpty()) {
-            xhibitDataService.markRecordSheetsAsErrored(erroredRecordSheets, recordSheetType);
+            List<String> filenames = erroredRecordSheets.stream().map(XhibitRecordSheetDTO::getFilename).toList();
+            xhibitDataService.markRecordSheetsAsErrored(filenames, recordSheetType);
             log.info("Marked errored record sheets { records: {} }.", erroredRecordSheets.size());
         }
 
@@ -52,14 +62,33 @@ public class TrialDataService {
             return;
         }
 
+        List<String> successfulProcedureFilenames = new ArrayList<>();
+        List<String> failedProcedureFilenames = new ArrayList<>();
         for (XhibitTrialDataEntity record : toProcess) {
-            Map<String, Object> inputParams = Map.of("id", record.getId());
-            storedProcedureService.callStoredProcedure(TRIAL_DATA_TO_MAAT_PROCEDURE, inputParams, OUTPUT_PARAMS);
+            Collection<StoredProcedureParameter<?>> parameters = getProcedureParameters(record);
+            try {
+                storedProcedureService.callStoredProcedure(TRIAL_DATA_TO_MAAT_PROCEDURE, parameters);
+                successfulProcedureFilenames.add(record.getFilename());
+            } catch (StoredProcedureException e) {
+                failedProcedureFilenames.add(record.getFilename());
+            }
         }
-        log.info("Processed trial data in to MAAT. { records: {} }", toProcess.size());
 
-        xhibitDataService.markRecordSheetsAsProcessed(recordSheets, recordSheetType);
+        if (!failedProcedureFilenames.isEmpty()) {
+            xhibitDataService.markRecordSheetsAsErrored(failedProcedureFilenames, recordSheetType);
+            log.info("Marked errored record sheets from failed stored procedure { records: {} }.", failedProcedureFilenames.size());
+        }
+
+        log.info("Processed trial data in to MAAT. { records: {} }", successfulProcedureFilenames.size());
+
+        xhibitDataService.markRecordSheetsAsProcessed(successfulProcedureFilenames, recordSheetType);
         log.info("Marked trial record sheets as processed.");
+    }
+
+    private static Collection<StoredProcedureParameter<?>> getProcedureParameters(XhibitTrialDataEntity record) {
+        Collection<StoredProcedureParameter<?>> parameters = new ArrayList<>(OUTPUT_PARAMETERS);
+        parameters.add(inputParameter("id", record.getId()));
+        return parameters;
     }
 
     private void saveRecordSheets(List<XhibitRecordSheetDTO> recordSheets) {

--- a/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/service/XhibitDataService.java
+++ b/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/service/XhibitDataService.java
@@ -94,13 +94,11 @@ public class XhibitDataService {
         }
     }
 
-    public void markRecordSheetsAsProcessed(List<XhibitRecordSheetDTO> recordSheets, RecordSheetType recordSheetType) {
-        List<String> filenames = recordSheets.stream().map(XhibitRecordSheetDTO::getFilename).toList();
+    public void markRecordSheetsAsProcessed(List<String> filenames, RecordSheetType recordSheetType) {
         renameRecordSheets(filenames, recordSheetType, RecordSheetStatus.PROCESSED);
     }
 
-    public void markRecordSheetsAsErrored(List<XhibitRecordSheetDTO> recordSheets, RecordSheetType recordSheetType) {
-        List<String> filenames = recordSheets.stream().map(XhibitRecordSheetDTO::getFilename).toList();
+    public void markRecordSheetsAsErrored(List<String> filenames, RecordSheetType recordSheetType) {
         renameRecordSheets(filenames, recordSheetType, RecordSheetStatus.ERRORED);
     }
 

--- a/maat-scheduled-tasks/src/test/java/uk/gov/justice/laa/maat/scheduled/tasks/helper/StoredProcedureParameterTest.java
+++ b/maat-scheduled-tasks/src/test/java/uk/gov/justice/laa/maat/scheduled/tasks/helper/StoredProcedureParameterTest.java
@@ -1,0 +1,43 @@
+package uk.gov.justice.laa.maat.scheduled.tasks.helper;
+
+import jakarta.persistence.ParameterMode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static uk.gov.justice.laa.maat.scheduled.tasks.helper.StoredProcedureParameter.inOutParameter;
+import static uk.gov.justice.laa.maat.scheduled.tasks.helper.StoredProcedureParameter.inputParameter;
+import static uk.gov.justice.laa.maat.scheduled.tasks.helper.StoredProcedureParameter.outputParameter;
+
+class StoredProcedureParameterTest {
+
+    @Test
+    void testInputParameter() {
+        StoredProcedureParameter<String> param = inputParameter("username", "name");
+
+        assertEquals("username", param.getName());
+        assertEquals(String.class, param.getType());
+        assertEquals("name", param.getValue());
+        assertEquals(ParameterMode.IN, param.getMode());
+    }
+
+    @Test
+    void testOutputParameter() {
+        StoredProcedureParameter<Integer> param = outputParameter("userId", Integer.class);
+
+        assertEquals("userId", param.getName());
+        assertEquals(Integer.class, param.getType());
+        assertNull(param.getValue());
+        assertEquals(ParameterMode.OUT, param.getMode());
+    }
+
+    @Test
+    void testInOutParameter() {
+        StoredProcedureParameter<Boolean> param = inOutParameter("active", true);
+
+        assertEquals("active", param.getName());
+        assertEquals(Boolean.class, param.getType());
+        assertEquals(true, param.getValue());
+        assertEquals(ParameterMode.INOUT, param.getMode());
+    }
+}

--- a/maat-scheduled-tasks/src/test/java/uk/gov/justice/laa/maat/scheduled/tasks/service/StoredProcedureServiceTest.java
+++ b/maat-scheduled-tasks/src/test/java/uk/gov/justice/laa/maat/scheduled/tasks/service/StoredProcedureServiceTest.java
@@ -9,15 +9,20 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.maat.scheduled.tasks.exception.StoredProcedureException;
+import uk.gov.justice.laa.maat.scheduled.tasks.helper.StoredProcedureParameter;
 
-import java.util.Collections;
-import java.util.Map;
+import java.util.Collection;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.justice.laa.maat.scheduled.tasks.helper.StoredProcedureParameter.inOutParameter;
+import static uk.gov.justice.laa.maat.scheduled.tasks.helper.StoredProcedureParameter.inputParameter;
+import static uk.gov.justice.laa.maat.scheduled.tasks.helper.StoredProcedureParameter.outputParameter;
 
 @ExtendWith(MockitoExtension.class)
 class StoredProcedureServiceTest {
@@ -79,40 +84,58 @@ class StoredProcedureServiceTest {
     }
 
     @Test
-    void testCallStoredProcedure_withParameters_registeredAndSetSuccessfully() {
+    void testCalledStoredProcedure_withParameters_registeredAndExecutedSuccessfully() {
         String procedureName = "my_procedure";
-        Map<String, Object> inputParams = Map.of("param1", "value1", "param2", 3);
-
-        when(entityManager.createStoredProcedureQuery(procedureName)).thenReturn(storedProcedureQuery);
-
-        storedProcedureService.callStoredProcedure(procedureName, inputParams, Collections.emptyMap());
-
-        verify(storedProcedureQuery).registerStoredProcedureParameter("param1", String.class, ParameterMode.IN);
-        verify(storedProcedureQuery).registerStoredProcedureParameter("param2", Integer.class, ParameterMode.IN);
-        verify(storedProcedureQuery).setParameter("param1", "value1");
-        verify(storedProcedureQuery).setParameter("param2", 3);
-        verify(storedProcedureQuery).execute();
-    }
-
-    @Test
-    void testCallStoredProcedure_WithInAndOutParams_registeredAndSetSuccessfully() {
-        String procedureName = "my_procedure";
-        Map<String, Object> inputParams = Map.of("inParam1", "value1", "inParam2", 3);
-        Map<String, Class<?>> outParams = Map.of("outParam1", String.class, "outParam2", Integer.class);
+        Collection<StoredProcedureParameter<?>> parameters = List.of(
+            inputParameter("inParam1", "value1"),
+            inputParameter("inParam2", 3),
+            outputParameter("outParam1", String.class),
+            outputParameter("outParam2", Integer.class),
+            inOutParameter("inOutParam1", "inOutValue"),
+            inOutParameter("inOutParam2", 1234L)
+        );
 
         when(entityManager.createStoredProcedureQuery(procedureName)).thenReturn(storedProcedureQuery);
         when(storedProcedureQuery.getOutputParameterValue("outParam1")).thenReturn("returnValue");
         when(storedProcedureQuery.getOutputParameterValue("outParam2")).thenReturn(5);
+        when(storedProcedureQuery.getOutputParameterValue("inOutParam1")).thenReturn("inOutValue");
+        when(storedProcedureQuery.getOutputParameterValue("inOutParam2")).thenReturn(1234L);
 
-        storedProcedureService.callStoredProcedure(procedureName, inputParams, outParams);
+        storedProcedureService.callStoredProcedure(procedureName, parameters);
 
         verify(storedProcedureQuery).registerStoredProcedureParameter("inParam1", String.class, ParameterMode.IN);
         verify(storedProcedureQuery).registerStoredProcedureParameter("inParam2", Integer.class, ParameterMode.IN);
         verify(storedProcedureQuery).registerStoredProcedureParameter("outParam1", String.class, ParameterMode.OUT);
         verify(storedProcedureQuery).registerStoredProcedureParameter("outParam2", Integer.class, ParameterMode.OUT);
+        verify(storedProcedureQuery).registerStoredProcedureParameter("inOutParam1", String.class, ParameterMode.INOUT);
+        verify(storedProcedureQuery).registerStoredProcedureParameter("inOutParam2", Long.class, ParameterMode.INOUT);
+
         verify(storedProcedureQuery).setParameter("inParam1", "value1");
         verify(storedProcedureQuery).setParameter("inParam2", 3);
+        verify(storedProcedureQuery).setParameter("inOutParam1", "inOutValue");
+        verify(storedProcedureQuery).setParameter("inOutParam2", 1234L);
+
         verify(storedProcedureQuery).execute();
     }
 
+    @Test
+    void executedStoredProcedure_outputParams_valuesRetrievedForLogging() {
+        String procedureName = "my_procedure";
+        Collection<StoredProcedureParameter<?>> parameters = List.of(
+            inputParameter("inParam1", "value1"),
+            outputParameter("outParam1", String.class),
+            inOutParameter("inOutParam1", "inOutValue")
+        );
+
+        when(entityManager.createStoredProcedureQuery(procedureName)).thenReturn(storedProcedureQuery);
+        when(storedProcedureQuery.getOutputParameterValue("outParam1")).thenReturn("returnValue");
+        when(storedProcedureQuery.getOutputParameterValue("inOutParam1")).thenReturn("inOutValue");
+
+        storedProcedureService.callStoredProcedure(procedureName, parameters);
+
+        verify(storedProcedureQuery).execute();
+        verify(storedProcedureQuery).getOutputParameterValue("outParam1");
+        verify(storedProcedureQuery).getOutputParameterValue("inOutParam1");
+        verify(storedProcedureQuery, never()).getOutputParameterValue("inParam");
+    }
 }

--- a/maat-scheduled-tasks/src/test/java/uk/gov/justice/laa/maat/scheduled/tasks/service/TrialDataServiceTest.java
+++ b/maat-scheduled-tasks/src/test/java/uk/gov/justice/laa/maat/scheduled/tasks/service/TrialDataServiceTest.java
@@ -8,20 +8,23 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.maat.scheduled.tasks.dto.XhibitRecordSheetDTO;
 import uk.gov.justice.laa.maat.scheduled.tasks.entity.XhibitTrialDataEntity;
 import uk.gov.justice.laa.maat.scheduled.tasks.enums.RecordSheetType;
+import uk.gov.justice.laa.maat.scheduled.tasks.exception.StoredProcedureException;
+import uk.gov.justice.laa.maat.scheduled.tasks.helper.StoredProcedureParameter;
 import uk.gov.justice.laa.maat.scheduled.tasks.repository.XhibitTrialDataRepository;
 import uk.gov.justice.laa.maat.scheduled.tasks.responses.GetRecordSheetsResponse;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.justice.laa.maat.scheduled.tasks.service.TrialDataService.OUTPUT_PARAMS;
+import static uk.gov.justice.laa.maat.scheduled.tasks.service.TrialDataService.OUTPUT_PARAMETERS;
 import static uk.gov.justice.laa.maat.scheduled.tasks.service.TrialDataService.TRIAL_DATA_TO_MAAT_PROCEDURE;
 
 @ExtendWith(MockitoExtension.class)
@@ -62,11 +65,16 @@ class TrialDataServiceTest {
         verify(xhibitDataService, times(1)).getAllRecordSheets(RecordSheetType.TRIAL);
         verify(xhibitDataService, never()).markRecordSheetsAsProcessed(any(), any());
         verify(xhibitDataService, never()).markRecordSheetsAsErrored(any(), any());
-        verify(storedProcedureService, never()).callStoredProcedure(any(), any(), anyMap());
+        verify(storedProcedureService, never()).callStoredProcedure(any(), any());
     }
 
     @Test
     void givenUnprocessRecordSheetsThatAreSuccessfullyRetrieved_whenPopulateAndProcessTrialDataIsInvoked_thenDataInToMaatIsPopulated() {
+        List<StoredProcedureParameter<?>> procedureParameters1 = new ArrayList<>(OUTPUT_PARAMETERS);
+        procedureParameters1.add(StoredProcedureParameter.inputParameter("id", 1));
+        List<StoredProcedureParameter<?>> procedureParameters2 = new ArrayList<>(OUTPUT_PARAMETERS);
+        procedureParameters2.add(StoredProcedureParameter.inputParameter("id", 2));
+
         when(getRecordSheetsResponse.getRetrievedRecordSheets()).thenReturn(List.of(xhibitRecordSheet1, xhibitRecordSheet2));
         when(getRecordSheetsResponse.getErroredRecordSheets()).thenReturn(Collections.emptyList());
 
@@ -80,9 +88,9 @@ class TrialDataServiceTest {
 
         verify(trialDataRepository, times(1)).saveAll(any());
         verify(xhibitDataService, times(1)).getAllRecordSheets(RecordSheetType.TRIAL);
-        verify(storedProcedureService, times(1)).callStoredProcedure(TRIAL_DATA_TO_MAAT_PROCEDURE, Map.of("id", 1), OUTPUT_PARAMS);
-        verify(storedProcedureService, times(1)).callStoredProcedure(TRIAL_DATA_TO_MAAT_PROCEDURE, Map.of("id", 2), OUTPUT_PARAMS);
-        verify(xhibitDataService, times(1)).markRecordSheetsAsProcessed(List.of(xhibitRecordSheet1, xhibitRecordSheet2), RecordSheetType.TRIAL);
+        verify(storedProcedureService, times(1)).callStoredProcedure(TRIAL_DATA_TO_MAAT_PROCEDURE, procedureParameters1);
+        verify(storedProcedureService, times(1)).callStoredProcedure(TRIAL_DATA_TO_MAAT_PROCEDURE, procedureParameters2);
+        verify(xhibitDataService, times(1)).markRecordSheetsAsProcessed(List.of(xhibitRecordSheet1.getFilename(), xhibitRecordSheet2.getFilename()), RecordSheetType.TRIAL);
         verify(xhibitDataService, never()).markRecordSheetsAsErrored(any(), any());
     }
 
@@ -110,6 +118,11 @@ class TrialDataServiceTest {
             .allRecordSheetsRetrieved(true)
             .build();
 
+        List<StoredProcedureParameter<?>> procedureParameters1 = new ArrayList<>(OUTPUT_PARAMETERS);
+        procedureParameters1.add(StoredProcedureParameter.inputParameter("id", 1));
+        List<StoredProcedureParameter<?>> procedureParameters2 = new ArrayList<>(OUTPUT_PARAMETERS);
+        procedureParameters2.add(StoredProcedureParameter.inputParameter("id", 2));
+
         when(xhibitDataService.getAllRecordSheets(RecordSheetType.TRIAL)).thenReturn(response);
         when(xhibitDataService.getAllRecordSheets(RecordSheetType.TRIAL)).thenReturn(response);
         when(trialDataRepository.findAll()).thenReturn(List.of(
@@ -121,9 +134,36 @@ class TrialDataServiceTest {
 
         verify(trialDataRepository, times(1)).saveAll(any());
         verify(xhibitDataService, times(1)).getAllRecordSheets(RecordSheetType.TRIAL);
-        verify(storedProcedureService, times(1)).callStoredProcedure(TRIAL_DATA_TO_MAAT_PROCEDURE, Map.of("id", 1), OUTPUT_PARAMS);
-        verify(storedProcedureService, times(1)).callStoredProcedure(TRIAL_DATA_TO_MAAT_PROCEDURE, Map.of("id", 2), OUTPUT_PARAMS);
-        verify(xhibitDataService, times(1)).markRecordSheetsAsProcessed(List.of(xhibitRecordSheet1, xhibitRecordSheet2), RecordSheetType.TRIAL);
+        verify(storedProcedureService, times(1)).callStoredProcedure(TRIAL_DATA_TO_MAAT_PROCEDURE, procedureParameters1);
+        verify(storedProcedureService, times(1)).callStoredProcedure(TRIAL_DATA_TO_MAAT_PROCEDURE, procedureParameters2);
+        verify(xhibitDataService, times(1)).markRecordSheetsAsProcessed(List.of(xhibitRecordSheet1.getFilename(), xhibitRecordSheet2.getFilename()), RecordSheetType.TRIAL);
         verify(xhibitDataService, never()).markRecordSheetsAsErrored(any(), any());
+    }
+
+    @Test
+    void givenStoredProcedureFailures_whenHandlingExceptions_FailedRecordsAreMarked() {
+        List<StoredProcedureParameter<?>> procedureParameters1 = new ArrayList<>(OUTPUT_PARAMETERS);
+        procedureParameters1.add(StoredProcedureParameter.inputParameter("id", 1));
+        List<StoredProcedureParameter<?>> procedureParameters2 = new ArrayList<>(OUTPUT_PARAMETERS);
+        procedureParameters2.add(StoredProcedureParameter.inputParameter("id", 2));
+
+        when(getRecordSheetsResponse.getRetrievedRecordSheets()).thenReturn(List.of(xhibitRecordSheet1, xhibitRecordSheet2));
+        when(getRecordSheetsResponse.getErroredRecordSheets()).thenReturn(Collections.emptyList());
+
+        when(xhibitDataService.getAllRecordSheets(RecordSheetType.TRIAL)).thenReturn(getRecordSheetsResponse);
+        when(trialDataRepository.findAll()).thenReturn(List.of(
+            XhibitTrialDataEntity.builder().id(1).filename(xhibitRecordSheet1.getFilename()).data(xhibitRecordSheet1.getData()).build(),
+            XhibitTrialDataEntity.builder().id(2).filename(xhibitRecordSheet2.getFilename()).data(xhibitRecordSheet2.getData()).build()
+        ));
+
+        doNothing().when(storedProcedureService).callStoredProcedure(TRIAL_DATA_TO_MAAT_PROCEDURE, procedureParameters1);
+        doThrow(StoredProcedureException.class).when(storedProcedureService).callStoredProcedure(TRIAL_DATA_TO_MAAT_PROCEDURE, procedureParameters2);
+
+        trialDataService.populateAndProcessTrialDataInToMaat();
+
+        verify(storedProcedureService, times(1)).callStoredProcedure(TRIAL_DATA_TO_MAAT_PROCEDURE, procedureParameters1);
+        verify(storedProcedureService, times(1)).callStoredProcedure(TRIAL_DATA_TO_MAAT_PROCEDURE, procedureParameters2);
+        verify(xhibitDataService, times(1)).markRecordSheetsAsProcessed(List.of(xhibitRecordSheet1.getFilename()), RecordSheetType.TRIAL);
+        verify(xhibitDataService, times(1)).markRecordSheetsAsErrored(List.of(xhibitRecordSheet2.getFilename()), RecordSheetType.TRIAL);
     }
 }

--- a/maat-scheduled-tasks/src/test/java/uk/gov/justice/laa/maat/scheduled/tasks/service/XhibitDataServiceTest.java
+++ b/maat-scheduled-tasks/src/test/java/uk/gov/justice/laa/maat/scheduled/tasks/service/XhibitDataServiceTest.java
@@ -157,7 +157,7 @@ class XhibitDataServiceTest {
         setupCopyResponse("trial/file2.xml", "processed/trial/file2.xml", true);
         setupDeleteResponse();
 
-        xhibitDataService.markRecordSheetsAsProcessed(List.of(xhibitRecordSheet1, xhibitRecordSheet2), RecordSheetType.TRIAL);
+        xhibitDataService.markRecordSheetsAsProcessed(List.of(xhibitRecordSheet1.getFilename(), xhibitRecordSheet2.getFilename()), RecordSheetType.TRIAL);
 
         verify(s3Client, times(1)).copyObject(argThat(
             new CopyObjectRequestArgumentMatcher("trial/file1.xml", "processed/trial/file1.xml")));
@@ -175,7 +175,7 @@ class XhibitDataServiceTest {
         setupCopyResponse("trial/file2.xml", "processed/trial/file2.xml", true);
         setupDeleteResponse();
 
-        xhibitDataService.markRecordSheetsAsProcessed(List.of(xhibitRecordSheet1, xhibitRecordSheet2), RecordSheetType.TRIAL);
+        xhibitDataService.markRecordSheetsAsProcessed(List.of(xhibitRecordSheet1.getFilename(), xhibitRecordSheet2.getFilename()), RecordSheetType.TRIAL);
 
         verify(s3Client, times(2)).copyObject(ArgumentMatchers.any(CopyObjectRequest.class));
         verify(s3Client, never()).deleteObject(argThat(
@@ -189,7 +189,7 @@ class XhibitDataServiceTest {
         setupCopyResponse("trial/file1.xml", "processed/trial/file1.xml", true);
         doThrow(SdkClientException.class).when(s3Client).deleteObject(ArgumentMatchers.any(DeleteObjectRequest.class));
 
-        assertThrows(XhibitDataServiceException.class, () -> xhibitDataService.markRecordSheetsAsProcessed(List.of(xhibitRecordSheet1), RecordSheetType.TRIAL));
+        assertThrows(XhibitDataServiceException.class, () -> xhibitDataService.markRecordSheetsAsProcessed(List.of(xhibitRecordSheet1.getFilename()), RecordSheetType.TRIAL));
     }
 
     private void setupCopyResponse(String sourceKey, String destinationKey, boolean successful) {


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4259)

- Ensure exceptions thrown by StoredProcedureService are caught
    - Handled by calling services 
- Mark records as errored if the corresponding stored procedure fails
    - Filenames are used to mark records
    - Similarly, ensure records aren't marked as processed if the stored procedure fails
- Abstract stored procedure parameters to be more generic and extensible
    - Parameters are now represented as `StoredProcedureParameter`s
    - These are now passed to the `StoredProcedureService` as a single collection
    
## Checklist

Before you ask people to review this PR:

- [X] Tests should be passing: `./gradlew test`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [X] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [X] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.
