### PR TITLE
LASB-4401|Migrate FDC Data Load HUB job

### DIFF
--- a/helm_deploy/laa-maat-scheduled-tasks/templates/_environment.tpl
+++ b/helm_deploy/laa-maat-scheduled-tasks/templates/_environment.tpl
@@ -15,6 +15,8 @@ env:
     value: {{ .Values.host_env }}
   - name: SENTRY_SAMPLE_RATE
     value: {{ .Values.sentry.sampleRate | quote }}
+  - name: SCOPE_API
+    value: {{ .Values.scope }}
   - name: LMR_REPORTS
     valueFrom:
         secretKeyRef:

--- a/helm_deploy/laa-maat-scheduled-tasks/values-dev.yaml
+++ b/helm_deploy/laa-maat-scheduled-tasks/values-dev.yaml
@@ -86,6 +86,8 @@ actuator:
 jwt:
   issuerUri: https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_JODrSUTLu
 
+scope: maat-scheduled-tasks-dev
+
 cclfApi:
   baseUrl: https://cclf-dev.apps.live.cloud-platform.service.justice.gov.uk/cclf/api/v1
   oauthUrl: https://cclf-dev.auth.eu-west-2.amazoncognito.com/oauth2/token

--- a/helm_deploy/laa-maat-scheduled-tasks/values-prod.yaml
+++ b/helm_deploy/laa-maat-scheduled-tasks/values-prod.yaml
@@ -86,6 +86,8 @@ actuator:
 jwt:
   issuerUri: https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_6zQ04ggE4
 
+scope: maat-scheduled-tasks-prod
+
 cclfApi:
   baseUrl: https://cclf.apps.live.cloud-platform.service.justice.gov.uk/cclf/api/v1
   oauthUrl: https://cclf-production.auth.eu-west-2.amazoncognito.com/oauth2/token

--- a/helm_deploy/laa-maat-scheduled-tasks/values-test.yaml
+++ b/helm_deploy/laa-maat-scheduled-tasks/values-test.yaml
@@ -86,6 +86,8 @@ actuator:
 jwt:
   issuerUri: https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_JCDC3oGQz
 
+scope: maat-scheduled-tasks-test
+
 cclfApi:
   baseUrl: https://cclf-staging.apps.live.cloud-platform.service.justice.gov.uk/cclf/api/v1
   oauthUrl: https://cclf-staging.auth.eu-west-2.amazoncognito.com/oauth2/token

--- a/helm_deploy/laa-maat-scheduled-tasks/values-uat.yaml
+++ b/helm_deploy/laa-maat-scheduled-tasks/values-uat.yaml
@@ -86,6 +86,8 @@ actuator:
 jwt:
   issuerUri: https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_uKC0C8X8e
 
+scope: maat-scheduled-tasks-uat
+
 cclfApi:
   baseUrl: https://cclf-uat.apps.live.cloud-platform.service.justice.gov.uk/cclf/api/v1
   oauthUrl: https://cclf-uat.auth.eu-west-2.amazoncognito.com/oauth2/token

--- a/maat-scheduled-tasks/build.gradle
+++ b/maat-scheduled-tasks/build.gradle
@@ -47,6 +47,7 @@ dependencies {
 	implementation "org.springframework.boot:spring-boot-starter-validation"
 	implementation "org.springframework.boot:spring-boot-starter-data-jpa"
 	implementation "org.springframework.boot:spring-boot-starter-oauth2-client"
+	implementation "org.springframework.boot:spring-boot-starter-oauth2-resource-server"
 	implementation "io.github.resilience4j:resilience4j-reactor:$versions.resilience4j"
 	implementation "io.github.resilience4j:resilience4j-spring-boot3:$versions.resilience4j"
 	implementation "com.oracle.database.jdbc:ojdbc11:$versions.ojdbcVersion"

--- a/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/config/ResourceServerConfiguration.java
+++ b/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/config/ResourceServerConfiguration.java
@@ -1,0 +1,49 @@
+package uk.gov.justice.laa.maat.scheduled.tasks.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationEntryPoint;
+import org.springframework.security.oauth2.server.resource.web.access.BearerTokenAccessDeniedHandler;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+@Configuration
+@EnableWebSecurity
+public class ResourceServerConfiguration {
+
+    @Value("${httpRequest.scope}")
+    private String maatScheduledTasksScope;
+
+    @Bean
+    protected BearerTokenAuthenticationEntryPoint bearerTokenAuthenticationEntryPoint() {
+        BearerTokenAuthenticationEntryPoint bearerTokenAuthenticationEntryPoint = new BearerTokenAuthenticationEntryPoint();
+        bearerTokenAuthenticationEntryPoint.setRealmName("Crime MAAT Scheduled Tasks API");
+        return bearerTokenAuthenticationEntryPoint;
+    }
+
+    @Bean
+    public AccessDeniedHandler bearerTokenAccessDeniedHandler() {
+        return new BearerTokenAccessDeniedHandler();
+    }
+
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/**").hasAuthority("SCOPE_" + maatScheduledTasksScope + "/standard")
+                        .anyRequest().authenticated())
+                .oauth2ResourceServer((oauth2ResourceServer) ->
+                        oauth2ResourceServer
+                                .accessDeniedHandler(bearerTokenAccessDeniedHandler())
+                                .authenticationEntryPoint(bearerTokenAuthenticationEntryPoint())
+                                .jwt(Customizer.withDefaults()));
+        return http.build();
+    }
+}

--- a/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/config/WebClientsConfig.java
+++ b/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/config/WebClientsConfig.java
@@ -1,31 +1,7 @@
 package uk.gov.justice.laa.maat.scheduled.tasks.config;
 
-import io.github.resilience4j.retry.RetryRegistry;
-import io.netty.resolver.DefaultAddressResolverGroup;
 import lombok.AllArgsConstructor;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.web.reactive.function.client.WebClientCustomizer;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.http.client.reactive.ReactorClientHttpConnector;
-import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
-import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
-import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction;
-import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
-import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.support.WebClientAdapter;
-import org.springframework.web.service.invoker.HttpServiceProxyFactory;
-import reactor.netty.http.client.HttpClient;
-import reactor.netty.resources.ConnectionProvider;
-import uk.gov.justice.laa.maat.scheduled.tasks.client.CrownCourtLitigatorFeesApiClient;
-import uk.gov.justice.laa.maat.scheduled.tasks.client.CrownCourtRemunerationApiClient;
-import uk.gov.justice.laa.maat.scheduled.tasks.filter.Resilience4jRetryFilter;
-import uk.gov.justice.laa.maat.scheduled.tasks.filter.WebClientFilters;
-
-import java.time.Duration;
-import java.util.List;
 
 @Configuration
 @AllArgsConstructor

--- a/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/controller/FinalDefenceCostsController.java
+++ b/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/controller/FinalDefenceCostsController.java
@@ -1,0 +1,89 @@
+package uk.gov.justice.laa.maat.scheduled.tasks.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.justice.laa.maat.scheduled.tasks.enums.FDCType;
+import uk.gov.justice.laa.maat.scheduled.tasks.responses.LoadFDCResponse;
+import uk.gov.justice.laa.maat.scheduled.tasks.service.FDCDataLoadService;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/internal/v1/fdc")
+public class FinalDefenceCostsController {
+    private final FDCDataLoadService fdcDataLoadService;
+
+    @PostMapping("load-fdc")
+    public ResponseEntity<LoadFDCResponse> loadFdc(
+            @RequestParam String fileName
+    ) {
+        FDCType itemType = getFdcType(fileName);
+
+        if (itemType == null) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+                    new LoadFDCResponse(false, 0,
+                            String.format("Invalid filename %s", fileName))
+            );
+        }
+
+        int recordsInserted = fdcDataLoadService.loadFinalDefenceCosts(fileName, itemType, 1000);
+        if (recordsInserted > 0) {
+            return ResponseEntity.ok(
+                new LoadFDCResponse(true, recordsInserted,
+                    String.format("Loaded dataset from file: %s", fileName))
+            );
+        } else {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+                    new LoadFDCResponse(false, 0,
+                            String.format("Failed to load dataset from file: %s", fileName))
+            );
+
+        }
+    }
+
+    @PostMapping("load-fdc-ready")
+    public ResponseEntity<LoadFDCResponse> loadFdcReady(
+            @RequestParam String fileName
+    ) {
+        FDCType itemType = getFdcType(fileName);
+
+        if (itemType == null) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+                    new LoadFDCResponse(false, 0,
+                            String.format("Invalid filename %s", fileName))
+            );
+        }
+        int recordsInserted = fdcDataLoadService.loadFdcReady(fileName, itemType, 1000);
+        if (recordsInserted > 0) {
+            return ResponseEntity.ok(
+                    new LoadFDCResponse(true, recordsInserted,
+                            String.format("Loaded dataset from file: %s", fileName))
+            );
+        } else {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+                    new LoadFDCResponse(false, 0,
+                            String.format("Failed to load dataset from file: %s", fileName))
+            );
+        }
+    }
+
+    @Nullable
+    private static FDCType getFdcType(String fileName) {
+        FDCType itemType;
+        if (fileName.toUpperCase().startsWith("CCR")) {
+            itemType = FDCType.AGFS;
+        } else if (fileName.toUpperCase().startsWith("CCLF")) {
+            itemType = FDCType.LGFS;
+        } else {
+            itemType = null;
+        }
+        return itemType;
+    }
+}

--- a/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/entity/FDCReadyEntity.java
+++ b/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/entity/FDCReadyEntity.java
@@ -1,0 +1,44 @@
+package uk.gov.justice.laa.maat.scheduled.tasks.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import uk.gov.justice.laa.maat.scheduled.tasks.enums.FDCType;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+@Entity
+@Table(name = "fdc_ready", schema = "HUB")
+public class FDCReadyEntity {
+    @Id
+    @SequenceGenerator(name = "fdc_ready_gen_seq", sequenceName = "S_GENERAL_SEQUENCE", allocationSize = 1, schema = "TOGDATA")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "fdc_ready_gen_seq")
+    @Column(name = "HDAT_ID")
+    private Integer hdatId;
+
+    @Column(name = "ID", nullable = false)
+    private Integer maatId;
+
+    @Column(name = "FDC_READY", length = 1)
+    private String fdcReady; // Y/N
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "ITEM_TYPE", length = 4)
+    private FDCType itemType; // LGFS or AGFS
+}

--- a/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/entity/FinalDefenceCostsEntity.java
+++ b/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/entity/FinalDefenceCostsEntity.java
@@ -1,0 +1,61 @@
+package uk.gov.justice.laa.maat.scheduled.tasks.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import uk.gov.justice.laa.maat.scheduled.tasks.enums.FDCType;
+
+import java.math.BigDecimal;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+@Entity
+@Table(name = "final_defence_costs", schema = "HUB")
+public class FinalDefenceCostsEntity {
+    @Id
+    @SequenceGenerator(name = "fdc_gen_seq", sequenceName = "S_GENERAL_SEQUENCE", allocationSize = 1, schema = "TOGDATA")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "fdc_gen_seq")
+    @Column(name = "HDAT_ID")
+    private Integer hdatId;
+
+    @Column(name = "ID")
+    private Integer maatId;
+
+    @Column(name = "CASE_NO", length = 40)
+    private String caseNo;
+
+    @Column(name = "SUPP_ACCOUNT_CODE", length = 10)
+    private String suppAccountCode;
+
+    @Column(name = "COUR_COURT_CODE", length = 10)
+    private String courCourtCode;
+
+    @Column(name = "JUDICIAL_APPORTIONMENT")
+    private int judicialApportionment;
+
+    @Column(name = "TOTAL_CASE_COSTS")
+    private BigDecimal totalCaseCosts;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "ITEM_TYPE", length = 4)
+    private FDCType itemType; // LGFS or AGFS
+
+    @Column(name = "PAID_AS_CLAIMED", length = 1)
+    private String paidAsClaimed; // Y/N
+}

--- a/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/enums/FDCType.java
+++ b/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/enums/FDCType.java
@@ -1,0 +1,5 @@
+package uk.gov.justice.laa.maat.scheduled.tasks.enums;
+
+public enum FDCType {
+    LGFS, AGFS
+}

--- a/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/responses/LoadFDCResponse.java
+++ b/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/responses/LoadFDCResponse.java
@@ -1,0 +1,3 @@
+package uk.gov.justice.laa.maat.scheduled.tasks.responses;
+
+public record LoadFDCResponse(boolean success, int recordsInserted, String message) {}

--- a/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/service/FDCDataLoadService.java
+++ b/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/service/FDCDataLoadService.java
@@ -1,0 +1,141 @@
+package uk.gov.justice.laa.maat.scheduled.tasks.service;
+
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.stereotype.Service;
+import uk.gov.justice.laa.maat.scheduled.tasks.entity.FDCReadyEntity;
+import uk.gov.justice.laa.maat.scheduled.tasks.entity.FinalDefenceCostsEntity;
+import uk.gov.justice.laa.maat.scheduled.tasks.enums.FDCType;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FDCDataLoadService {
+    private final ResourceLoader resourceLoader;
+    private final EntityManager entityManager;
+
+    // this method will be replaced to invoke the Billing API to load the data into MAAT DB
+    @Transactional
+    public int loadFinalDefenceCosts(String csvPath, FDCType itemType, int batchSize) {
+        log.info("Loading FDC Final Defence Costs");
+        int count = 0;
+        Resource resource = resourceLoader.getResource("classpath:" + csvPath);
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(resource.getInputStream()))) {
+            // read header
+            String headerLine = br.readLine();
+            if (headerLine == null) return 0;
+
+            Map<String, Integer> idx = headerIndex(headerLine.split(",", -1));
+            int inBatch = 0;
+            String line;
+            while ((line = br.readLine()) != null) {
+                if (line.isBlank()) continue;
+                String[] cols = line.split(",", -1);
+                FinalDefenceCostsEntity e = new FinalDefenceCostsEntity();
+                e.setMaatId(getInt(cols, idx, "maat_reference"));
+                e.setCaseNo(getStr(cols, idx, "case_no"));
+                e.setSuppAccountCode(getStr(cols, idx, "supp_account_code"));
+                e.setCourCourtCode(getStr(cols, idx, "court_code"));
+                e.setJudicialApportionment(getInt(cols, idx, "judicial_apportionment"));
+                e.setTotalCaseCosts(getDecimal(cols, idx));
+                e.setItemType(itemType);
+                e.setPaidAsClaimed(getStr(cols, idx, "paid_as_claimed"));
+
+                entityManager.persist(e);
+                inBatch++;
+                count++;
+
+                if (inBatch >= batchSize) {
+                    entityManager.flush();
+                    entityManager.clear();
+                    inBatch = 0;
+                }
+            }
+
+            if (inBatch > 0) {
+                entityManager.flush();
+                entityManager.clear();
+            }
+        } catch (IOException e) {
+            log.error("Failed to load FDC Final Defence Costs", e);
+        }
+        return count;
+    }
+
+    @Transactional
+    public int loadFdcReady(String csvPath, FDCType itemType, int batchSize) {
+        log.info("Loading FDC Ready");
+        int count = 0;
+        Resource resource = resourceLoader.getResource("classpath:" + csvPath);
+
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(resource.getInputStream()))) {
+            String headerLine = br.readLine();
+            if (headerLine == null) return 0;
+            Map<String, Integer> idx = headerIndex(headerLine.split(",", -1));
+            int inBatch = 0;
+            String line;
+            while ((line = br.readLine()) != null) {
+                if (line.isBlank()) continue;
+                String[] cols = line.split(",", -1);
+                FDCReadyEntity e = new FDCReadyEntity();
+                e.setMaatId(getInt(cols, idx, "maat_reference"));
+                e.setFdcReady(getStr(cols, idx, "fdc_ready"));
+                e.setItemType(itemType);
+                entityManager.persist(e);
+                inBatch++;
+                count++;
+
+                if (inBatch >= batchSize) {
+                    entityManager.flush();
+                    entityManager.clear();
+                    inBatch = 0;
+                }
+            }
+            if (inBatch > 0) {
+                entityManager.flush();
+                entityManager.clear();
+            }
+        } catch (IOException e) {
+            log.error("Failed to load FDC Ready", e);
+        }
+        return count;
+    }
+
+
+    private static Map<String, Integer> headerIndex(String[] headers) {
+        Map<String, Integer> idx = new HashMap<>();
+        for (int i = 0; i < headers.length; i++) {
+            idx.put(headers[i].trim().toUpperCase(), i);
+        }
+        return idx;
+    }
+
+    private static Integer getInt(String[] cols, Map<String, Integer> idx, String key) {
+        String v = getStr(cols, idx, key);
+        return (v == null) ? null : Integer.valueOf(v);
+    }
+
+    private static String getStr(String[] cols, Map<String, Integer> idx, String key) {
+        Integer i = idx.get(key.toUpperCase());
+        if (i == null || i >= cols.length) return null;
+        String v = cols[i].trim();
+        return v.isEmpty() ? null : v;
+    }
+
+
+    private static BigDecimal getDecimal(String[] cols, Map<String, Integer> idx) {
+        String v = getStr(cols, idx, "final_defence_cost");
+        return (v == null) ? null : new BigDecimal(v);
+    }
+}

--- a/maat-scheduled-tasks/src/main/resources/application.yaml
+++ b/maat-scheduled-tasks/src/main/resources/application.yaml
@@ -50,6 +50,9 @@ spring:
         jwt:
           issuer-uri: ${JWT_ISSUER_URI}
 
+httpRequest:
+  scope: ${SCOPE_API}
+
 maat_batch:
   lmr_reports:
     cron_expression:  ${LMR_REPORTS}

--- a/maat-scheduled-tasks/src/main/resources/sql/lasb_4401_create_fdc_ready_table.sql
+++ b/maat-scheduled-tasks/src/main/resources/sql/lasb_4401_create_fdc_ready_table.sql
@@ -1,0 +1,26 @@
+/*
+ Purpose    : Create the FDC_READY table that is used for storing the FDC Ready Data from Billing team
+ JIRA       : LASB-4401
+
+ Author     : Venkat Velpuri
+
+ History    :
+
+ Version  Date         Name              Description
+ ~~~~~~~  ~~~~~~~~~~   ~~~~~~~~~~~~~~   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ 1.0      3/09/2025   V Velpuri           Initial Version
+
+
+To be run as HUB@MAATDB
+
+*/
+CREATE TABLE HUB.FDC_READY (
+    HDAT_ID     NUMBER PRIMARY KEY,         -- Sequence Number
+    ID          NUMBER NOT NULL,            -- MAAT ID
+    FDC_READY   VARCHAR2(1 BYTE)
+                CHECK (FDC_READY IN ('Y','N')), -- Y/N
+    ITEM_TYPE   VARCHAR2(4 BYTE)
+                CHECK (ITEM_TYPE IN ('LGFS','AGFS')) -- CCLF or CCR
+);
+
+GRANT INSERT, SELECT, UPDATE, DELETE ON HUB.FDC_READY TO TOGDATA;

--- a/maat-scheduled-tasks/src/main/resources/sql/lasb_4401_create_fdc_ready_table_rollback.sql
+++ b/maat-scheduled-tasks/src/main/resources/sql/lasb_4401_create_fdc_ready_table_rollback.sql
@@ -1,0 +1,17 @@
+/*
+ Purpose    : Rollback the FDC_READY table that is used for storing the FDC Ready data from Billing team
+ JIRA       : LASB-4401
+
+ Author     : V Velpuri
+
+ History    :
+
+ Version  Date         Name              Description
+ ~~~~~~~  ~~~~~~~~~~   ~~~~~~~~~~~~~~   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ 1.0      03/09/2025   V Velpuri           Initial Version
+
+
+To be run as HUB@MAATDB
+
+*/
+DROP TABLE HUB.FDC_READY;

--- a/maat-scheduled-tasks/src/main/resources/sql/lasb_4401_create_final_defence_costs_table.sql
+++ b/maat-scheduled-tasks/src/main/resources/sql/lasb_4401_create_final_defence_costs_table.sql
@@ -1,0 +1,31 @@
+/*
+ Purpose    : Create the FINAL_DEFENCE_COSTS table that is used for storing the FDC Data from Billing team
+ JIRA       : LASB-4401
+
+ Author     : Venkat Velpuri
+
+ History    :
+
+ Version  Date         Name              Description
+ ~~~~~~~  ~~~~~~~~~~   ~~~~~~~~~~~~~~   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ 1.0      3/09/2025   V Velpuri           Initial Version
+
+
+To be run as HUB@MAATDB
+
+*/
+CREATE TABLE HUB.FINAL_DEFENCE_COSTS (
+     HDAT_ID                NUMBER PRIMARY KEY, -- Sequence number
+     ID                     NUMBER NOT NULL,    -- MAAT ID
+     CASE_NO                VARCHAR2(40 BYTE),
+     SUPP_ACCOUNT_CODE      VARCHAR2(10 BYTE),
+     COUR_COURT_CODE        VARCHAR2(10 BYTE),
+     JUDICIAL_APPORTIONMENT NUMBER,
+     TOTAL_CASE_COSTS       NUMBER,
+     ITEM_TYPE              VARCHAR2(4 BYTE)
+                            CHECK (ITEM_TYPE IN ('LGFS','AGFS')),
+     PAID_AS_CLAIMED        VARCHAR2(1 BYTE)
+                            CHECK (PAID_AS_CLAIMED IN ('Y','N'))
+);
+
+GRANT INSERT, SELECT, UPDATE, DELETE ON HUB.FINAL_DEFENCE_COSTS TO TOGDATA;

--- a/maat-scheduled-tasks/src/main/resources/sql/lasb_4401_create_final_defence_costs_table_rollback.sql
+++ b/maat-scheduled-tasks/src/main/resources/sql/lasb_4401_create_final_defence_costs_table_rollback.sql
@@ -1,0 +1,17 @@
+/*
+ Purpose    : Rollback the FINAL_DEFENCE_COSTS table that is used for storing the FDC data from Billing team
+ JIRA       : LASB-4401
+
+ Author     : V Velpuri
+
+ History    :
+
+ Version  Date         Name              Description
+ ~~~~~~~  ~~~~~~~~~~   ~~~~~~~~~~~~~~   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ 1.0      03/09/2025   V Velpuri           Initial Version
+
+
+To be run as TOGDATA@MAATDB
+
+*/
+DROP TABLE HUB.FINAL_DEFENCE_COSTS;

--- a/maat-scheduled-tasks/src/test/java/uk/gov/justice/laa/maat/scheduled/tasks/controller/FinalDefenceCostsControllerTest.java
+++ b/maat-scheduled-tasks/src/test/java/uk/gov/justice/laa/maat/scheduled/tasks/controller/FinalDefenceCostsControllerTest.java
@@ -1,0 +1,139 @@
+package uk.gov.justice.laa.maat.scheduled.tasks.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.justice.laa.maat.scheduled.tasks.enums.FDCType;
+import uk.gov.justice.laa.maat.scheduled.tasks.service.FDCDataLoadService;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(FinalDefenceCostsController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class FinalDefenceCostsControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private FDCDataLoadService fdcDataLoadService;
+
+    private static final String BASE = "/api/internal/v1/fdc";
+
+    @Test
+    @DisplayName("load-fdc: returns 400 for invalid filename")
+    void loadFdc_invalidFilename_returnsBadRequest() throws Exception {
+        mockMvc.perform(post(BASE + "/load-fdc")
+                        .param("fileName", "foo.csv"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.recordsInserted").value(0))
+                .andExpect(jsonPath("$.message", containsString("Invalid filename foo.csv")));
+
+        // Service must NOT be called
+        verifyNoInteractions(fdcDataLoadService);
+    }
+
+    @Test
+    @DisplayName("load-fdc: CCR* maps to AGFS and returns 200 with body when recordsInserted > 0")
+    void loadFdc_ccr_success() throws Exception {
+        when(fdcDataLoadService.loadFinalDefenceCosts(eq("CCR_202501.csv"), eq(FDCType.AGFS), eq(1000)))
+                .thenReturn(5);
+
+        mockMvc.perform(post(BASE + "/load-fdc")
+                        .param("fileName", "CCR_202501.csv"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.recordsInserted").value(5))
+                .andExpect(jsonPath("$.message", containsString("CCR_202501.csv")));
+
+        verify(fdcDataLoadService, times(1))
+                .loadFinalDefenceCosts("CCR_202501.csv", FDCType.AGFS, 1000);
+    }
+
+    @Test
+    @DisplayName("load-fdc: CCLF* maps to LGFS and returns 500 when recordsInserted == 0")
+    void loadFdc_cclf_failure500_whenZeroInserted() throws Exception {
+        when(fdcDataLoadService.loadFinalDefenceCosts(eq("CCLF_dump.csv"), eq(FDCType.LGFS), eq(1000)))
+                .thenReturn(0);
+
+        mockMvc.perform(post(BASE + "/load-fdc")
+                        .param("fileName", "CCLF_dump.csv"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.recordsInserted").value(0))
+                .andExpect(jsonPath("$.message", containsString("Failed to load dataset from file: CCLF_dump.csv")));
+
+        verify(fdcDataLoadService).loadFinalDefenceCosts("CCLF_dump.csv", FDCType.LGFS, 1000);
+    }
+
+    @Test
+    @DisplayName("load-fdc: mapping is case-insensitive (ccr* -> AGFS)")
+    void loadFdc_caseInsensitivePrefix() throws Exception {
+        when(fdcDataLoadService.loadFinalDefenceCosts(eq("ccr_small.csv"), eq(FDCType.AGFS), eq(1000)))
+                .thenReturn(1);
+
+        mockMvc.perform(post(BASE + "/load-fdc")
+                        .param("fileName", "ccr_small.csv"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.recordsInserted").value(1));
+
+        verify(fdcDataLoadService).loadFinalDefenceCosts("ccr_small.csv", FDCType.AGFS, 1000);
+    }
+
+    @Test
+    @DisplayName("load-fdc-ready: returns 400 for invalid filename")
+    void loadFdcReady_invalidFilename_returnsBadRequest() throws Exception {
+        mockMvc.perform(post(BASE + "/load-fdc-ready")
+                        .param("fileName", "random.txt"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.recordsInserted").value(0))
+                .andExpect(jsonPath("$.message", containsString("Invalid filename random.txt")));
+
+        verifyNoInteractions(fdcDataLoadService);
+    }
+
+    @Test
+    @DisplayName("load-fdc-ready: CCR* -> AGFS, 200 OK when > 0")
+    void loadFdcReady_success_agfs() throws Exception {
+        when(fdcDataLoadService.loadFdcReady(eq("CCR_ready.csv"), eq(FDCType.AGFS), eq(1000)))
+                .thenReturn(7);
+
+        mockMvc.perform(post(BASE + "/load-fdc-ready")
+                        .param("fileName", "CCR_ready.csv"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.recordsInserted").value(7))
+                .andExpect(jsonPath("$.message", containsString("CCR_ready.csv")));
+
+        verify(fdcDataLoadService).loadFdcReady("CCR_ready.csv", FDCType.AGFS, 1000);
+    }
+
+    @Test
+    @DisplayName("load-fdc-ready: CCLF* -> LGFS, 500 when 0")
+    void loadFdcReady_failure500_whenZero() throws Exception {
+        when(fdcDataLoadService.loadFdcReady(eq("CCLF_ready.csv"), eq(FDCType.LGFS), eq(1000)))
+                .thenReturn(0);
+
+        mockMvc.perform(post(BASE + "/load-fdc-ready")
+                        .param("fileName", "CCLF_ready.csv"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.recordsInserted").value(0))
+                .andExpect(jsonPath("$.message", containsString("Failed to load dataset from file: CCLF_ready.csv")));
+
+        verify(fdcDataLoadService).loadFdcReady("CCLF_ready.csv", FDCType.LGFS, 1000);
+    }
+}

--- a/maat-scheduled-tasks/src/test/java/uk/gov/justice/laa/maat/scheduled/tasks/service/FDCDataLoadServiceTest.java
+++ b/maat-scheduled-tasks/src/test/java/uk/gov/justice/laa/maat/scheduled/tasks/service/FDCDataLoadServiceTest.java
@@ -1,0 +1,193 @@
+package uk.gov.justice.laa.maat.scheduled.tasks.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import uk.gov.justice.laa.maat.scheduled.tasks.entity.FDCReadyEntity;
+import uk.gov.justice.laa.maat.scheduled.tasks.entity.FinalDefenceCostsEntity;
+import uk.gov.justice.laa.maat.scheduled.tasks.enums.FDCType;
+
+import jakarta.persistence.EntityManager;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FDCDataLoadServiceTest {
+
+    @Mock
+    private ResourceLoader resourceLoader;
+    @Mock
+    private EntityManager entityManager;
+    @Mock
+    private Resource resource;
+
+    @InjectMocks
+    private FDCDataLoadService service;
+
+    private void mockCsv(String csvPath, String csv) throws IOException {
+        when(resourceLoader.getResource("classpath:" + csvPath)).thenReturn(resource);
+        when(resource.getInputStream()).thenReturn(
+                new ByteArrayInputStream(csv.getBytes(StandardCharsets.UTF_8))
+        );
+    }
+
+    @Nested
+    class LoadFinalDefenceCosts {
+
+        @Test
+        @DisplayName("Parses rows, maps fields, sets itemType, returns count, and batches flush/clear")
+        void parsesAndPersistsWithBatching() throws Exception {
+            // batchSize = 2 to exercise batching with 3 data rows
+            String csv = String.join("\n",
+                    "maat_reference,case_no,supp_account_code,court_code,judicial_apportionment,final_defence_cost,paid_as_claimed",
+                    "1001,CASE1,SUP1,CRT1,1,123.45,YES",
+                    "1002,CASE2,SUP2,CRT2,0,0.00,NO",
+                    "1003,CASE3,SUP3,CRT3,2,98765.43,YES"
+            );
+            mockCsv("CCR_data.csv", csv);
+
+            int count = service.loadFinalDefenceCosts("CCR_data.csv", FDCType.AGFS, 2);
+
+            assertThat(count).isEqualTo(3);
+
+            // capture entities persisted
+            ArgumentCaptor<FinalDefenceCostsEntity> captor = ArgumentCaptor.forClass(FinalDefenceCostsEntity.class);
+            verify(entityManager, times(3)).persist(captor.capture());
+
+            List<FinalDefenceCostsEntity> all = captor.getAllValues();
+            FinalDefenceCostsEntity first = all.getFirst();
+            assertThat(first.getMaatId()).isEqualTo(1001);
+            assertThat(first.getCaseNo()).isEqualTo("CASE1");
+            assertThat(first.getSuppAccountCode()).isEqualTo("SUP1");
+            assertThat(first.getCourCourtCode()).isEqualTo("CRT1");
+            assertThat(first.getJudicialApportionment()).isEqualTo(1);
+            assertThat(first.getTotalCaseCosts()).isEqualByComparingTo(new BigDecimal("123.45"));
+            assertThat(first.getItemType()).isEqualTo(FDCType.AGFS);
+            assertThat(first.getPaidAsClaimed()).isEqualTo("YES");
+
+            FinalDefenceCostsEntity third = all.get(2);
+            assertThat(third.getMaatId()).isEqualTo(1003);
+            assertThat(third.getTotalCaseCosts()).isEqualByComparingTo(new BigDecimal("98765.43"));
+
+            // batching: expect flush/clear after row 2, and again at end for remaining row
+            verify(entityManager, times(2)).flush();
+            verify(entityManager, times(2)).clear();
+        }
+
+        @Test
+        @DisplayName("Blank lines are skipped")
+        void skipsBlankLines() throws Exception {
+            String csv = String.join("\n",
+                    "maat_reference,case_no,supp_account_code,court_code,judicial_apportionment,final_defence_cost,paid_as_claimed",
+                    "", // blank line
+                    "2001,CASEX,SUPX,CRTX,1,10.00,YES",
+                    "   ", // whitespace-only line
+                    "2002,CASEY,SUPY,CRTY,0,20.00,NO"
+            );
+            mockCsv("CCLF_data.csv", csv);
+
+            int count = service.loadFinalDefenceCosts("CCLF_data.csv", FDCType.LGFS, 10);
+
+            assertThat(count).isEqualTo(2);
+            verify(entityManager, times(2)).persist(any(FinalDefenceCostsEntity.class));
+        }
+
+        @Test
+        @DisplayName("Header-only (no data rows) returns 0 and does not persist")
+        void headerOnlyReturnsZero() throws Exception {
+            String csv = "maat_reference,case_no,supp_account_code,court_code,judicial_apportionment,final_defence_cost,paid_as_claimed\n";
+            mockCsv("empty.csv", csv);
+
+            int count = service.loadFinalDefenceCosts("empty.csv", FDCType.AGFS, 1000);
+
+            assertThat(count).isZero();
+            verify(entityManager, never()).persist(any());
+            verify(entityManager, never()).flush();
+            verify(entityManager, never()).clear();
+        }
+
+        @Test
+        @DisplayName("IOException while reading returns 0 and logs, without persisting")
+        void ioExceptionReturnsZero() throws Exception {
+            when(resourceLoader.getResource("classpath:bad.csv")).thenReturn(resource);
+            when(resource.getInputStream()).thenThrow(new IOException("boom"));
+
+            int count = service.loadFinalDefenceCosts("bad.csv", FDCType.AGFS, 1000);
+
+            assertThat(count).isZero();
+            verify(entityManager, never()).persist(any());
+        }
+    }
+
+    @Nested
+    class LoadFdcReady {
+
+        @Test
+        @DisplayName("Parses rows, maps fields, sets itemType, returns count, and batches")
+        void parsesAndPersistsReady() throws Exception {
+            String csv = String.join("\n",
+                    "maat_reference,FDC_READY",
+                    "3001,YES",
+                    "3002,NO",
+                    "3003,YES"
+            );
+            mockCsv("CCR_ready.csv", csv);
+
+            int count = service.loadFdcReady("CCR_ready.csv", FDCType.AGFS, 2);
+
+            assertThat(count).isEqualTo(3);
+
+            ArgumentCaptor<FDCReadyEntity> captor = ArgumentCaptor.forClass(FDCReadyEntity.class);
+            verify(entityManager, times(3)).persist(captor.capture());
+
+            List<FDCReadyEntity> all = captor.getAllValues();
+            assertThat(all.getFirst().getMaatId()).isEqualTo(3001);
+            assertThat(all.getFirst().getFdcReady()).isEqualTo("YES");
+            assertThat(all.getFirst().getItemType()).isEqualTo(FDCType.AGFS);
+
+            assertThat(all.get(1).getMaatId()).isEqualTo(3002);
+            assertThat(all.get(1).getFdcReady()).isEqualTo("NO");
+
+            verify(entityManager, times(2)).flush();
+            verify(entityManager, times(2)).clear();
+        }
+
+        @Test
+        @DisplayName("Header-only returns 0 (no persist)")
+        void readyHeaderOnly() throws Exception {
+            String csv = "maat_reference,FDC_READY\n";
+            mockCsv("ready_empty.csv", csv);
+
+            int count = service.loadFdcReady("ready_empty.csv", FDCType.LGFS, 1000);
+
+            assertThat(count).isZero();
+            verify(entityManager, never()).persist(any());
+        }
+
+        @Test
+        @DisplayName("IOException while reading returns 0")
+        void readyIOException() throws Exception {
+            when(resourceLoader.getResource("classpath:oops.csv")).thenReturn(resource);
+            when(resource.getInputStream()).thenThrow(new IOException("nope"));
+
+            int count = service.loadFdcReady("oops.csv", FDCType.LGFS, 1000);
+
+            assertThat(count).isZero();
+            verify(entityManager, never()).persist(any());
+        }
+    }
+}

--- a/maat-scheduled-tasks/src/test/resources/application.yaml
+++ b/maat-scheduled-tasks/src/test/resources/application.yaml
@@ -32,7 +32,10 @@ spring:
 
       resource-server:
         jwt:
-          issuer-uri: ${JWT_ISSUER_URI}
+          issuer-uri: ${JWT_ISSUER_URI:http://localhost:9999}
+
+httpRequest:
+  scope: maat-scheduled-tasks-dev
 
 maat_batch:
   lmr_reports:


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4401)

As a start to migrate the FDC Data load HUB job created the following:
New tables to temporarily store the FDC data that is sent from Billing team.
Service to read from the FDC .csv files and load into the new tables.
A controller to hit the new service to trigger the loading of the FDC data.

Also, set up the Resource Server config to enable OAuth2.
