### PR TITLE
Fix Scheduled Tasks deploy

### DIFF
--- a/helm_deploy/laa-maat-scheduled-tasks/templates/_environment.tpl
+++ b/helm_deploy/laa-maat-scheduled-tasks/templates/_environment.tpl
@@ -92,7 +92,7 @@ env:
   - name: AWS_DEFAULT_REGION
     value: {{ .Values.aws_region }}
   - name: XHIBIT_BATCH_FETCH_SIZE
-    value: {{ .Values.xhibitBatch.fetchSize }}
+    value: {{ .Values.xhibitBatch.fetchSize | quote }}
   - name: AWS_S3_XHIBIT_DATA_BUCKET_NAME
     valueFrom:
         secretKeyRef:

--- a/helm_deploy/laa-maat-scheduled-tasks/templates/ingress.yaml
+++ b/helm_deploy/laa-maat-scheduled-tasks/templates/ingress.yaml
@@ -38,7 +38,7 @@ spec:
           {{- range .paths }}
           - path: {{ .path }}
             {{- with .pathType }}
-            pathType: {{ . }}
+            pathType: {{ . | quote }}
             {{- end }}
             backend:
               service:

--- a/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/config/XhibitConfiguration.java
+++ b/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/config/XhibitConfiguration.java
@@ -26,5 +26,5 @@ public class XhibitConfiguration {
     private final String s3DataBucketName;
 
     @NotNull
-    private final int fetchSize;
+    private final String fetchSize;
 }

--- a/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/service/XhibitDataService.java
+++ b/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/service/XhibitDataService.java
@@ -52,7 +52,7 @@ public class XhibitDataService {
         String continuationToken = recordSheetsResponse.getContinuationToken();
         ListObjectsV2Request.Builder listObjectsRequestBuilder = ListObjectsV2Request.builder()
             .bucket(xhibitConfiguration.getS3DataBucketName())
-            .maxKeys(xhibitConfiguration.getFetchSize())
+            .maxKeys(Integer.parseInt(xhibitConfiguration.getFetchSize()))
             .prefix(objectKeyPrefix);
 
         if (continuationToken != null) {

--- a/maat-scheduled-tasks/src/test/java/uk/gov/justice/laa/maat/scheduled/tasks/service/XhibitDataServiceTest.java
+++ b/maat-scheduled-tasks/src/test/java/uk/gov/justice/laa/maat/scheduled/tasks/service/XhibitDataServiceTest.java
@@ -82,7 +82,7 @@ class XhibitDataServiceTest {
         lenient().when(xhibitConfiguration.getObjectKeyProcessedPrefix()).thenReturn("processed");
         lenient().when(xhibitConfiguration.getObjectKeyErroredPrefix()).thenReturn("errored");
         lenient().when(xhibitConfiguration.getS3DataBucketName()).thenReturn("bucket");
-        lenient().when(xhibitConfiguration.getFetchSize()).thenReturn(1);
+        lenient().when(xhibitConfiguration.getFetchSize()).thenReturn("1");
     }
 
     @Test


### PR DESCRIPTION
This PR fixes the ResourceServerConfiguration to allow actuator requests without requiring authentication. This is
necessary for Kubernetes to spin up pods, as the liveness and readiness probes point at the actuator healthcheck
endpoint.

Additionally, this PR fixes the Helm deploy, specifically to set the Xhibit batch `fetchSize` env var to be a string rather
than an int, which caused issues when running `helm upgrade` as the variable was attempting to be parsed into the wrong
data structure.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4405)
