### PR TITLE
Add success and failure slack notification to the environment deployment jobs.

### DIFF
--- a/.github/actions/slack-notify-composite-action/action.yml
+++ b/.github/actions/slack-notify-composite-action/action.yml
@@ -14,6 +14,7 @@ runs:
   using: "composite"
   steps:
     - name: Notify success to Slack
+      id: slack-success
       if: ${{ success() }}
       uses: slackapi/slack-github-action@v1
       with:
@@ -21,30 +22,50 @@ runs:
           {
             "blocks": [
               {
-                "type": "header",
+                "type": "section",
                 "text": {
-                  "type": "plain_text",
-                  "text": "Deployment Successful! :partying_face:",
-                  "emoji": true
+                  "type": "mrkdwn",
+                  "text": "*:white_check_mark: Succeeded GitHub Actions*"
                 }
               },
               {
                 "type": "section",
                 "fields": [
-                  { "type": "mrkdwn", "text": "*Project:* ${{ github.event.repository.name }}" },
-                  { "type": "mrkdwn", "text": "*When:* ${{ github.run_started_at }}" },
-                  { "type": "mrkdwn", "text": "*Branch:* \n${{ github.ref_name }}" },
-                  { "type": "mrkdwn", "text": "*Successful Job:* \n${{ github.job }}" }
-                ]
-              },
-              {
-                "type": "actions",
-                "elements": [
                   {
-                    "type": "button",
-                    "action_id": "deployment_link",
-                    "text": { "type": "plain_text", "text": "View Run" },
-                    "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    "type": "mrkdwn",
+                    "text": "*Repo*\n<https://github.com/${{ github.repository }}|${{ github.repository }}>"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Commit*\n<${{ github.event.head_commit.url }}|${{ env.SHORT_SHA }}>"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Author*\n${{ github.event.head_commit.author.name }}"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Job*\n`${{ github.job }}`"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Event Name*\n`${{ github.event_name }}`"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Workflow*\n`${{ github.workflow }}`"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Build Logs*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Took*\n`${{ steps.calculate_duration.outputs.duration }} sec`"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Message*\n${{ github.event.head_commit.message }}"
                   }
                 ]
               }
@@ -52,6 +73,7 @@ runs:
           }
       env:
         SLACK_WEBHOOK_URL: ${{ inputs.webhook-url }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
     - name: Notify failure to Slack (non-main branches only)
       if: ${{ failure() && github.ref_name != 'main' }}
@@ -68,3 +90,4 @@ runs:
           *Run:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
       env:
         SLACK_WEBHOOK_URL: ${{ inputs.webhook-url }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/actions/slack-notify-composite-action/action.yml
+++ b/.github/actions/slack-notify-composite-action/action.yml
@@ -38,7 +38,7 @@ runs:
                 "type": "section",
                 "fields": [
                   { "type": "mrkdwn", "text": "*Project:* ${{ github.event.repository.name }}" },
-                  { "type": "mrkdwn", "text": "*When:* ${{ env.BUILD_START_TIME }}" },
+                  { "type": "mrkdwn", "text": "*When:* ${{ github.env.BUILD_START_TIME }}" },
                   { "type": "mrkdwn", "text": "*Branch:* \n${{ github.ref_name }}" },
                   { "type": "mrkdwn", "text": "*Successful Job:* \n${{ github.job }}" }
                 ]

--- a/.github/actions/slack-notify-composite-action/action.yml
+++ b/.github/actions/slack-notify-composite-action/action.yml
@@ -14,10 +14,10 @@ runs:
   using: "composite"
   steps:
     - name: Calculate build start time
-      id: build-start-time
+      id: build-run-time
       shell: bash
       run: |
-        echo "BUILD_START_TIME=$(date +%s)" >> $GITHUB_ENV
+        echo "BUILD_RUN_TIME=$(date +'%m/%d/%Y %T')" >> $GITHUB_ENV
 
     - name: Notify success to Slack
       id: slack-success
@@ -39,7 +39,7 @@ runs:
                 "type": "section",
                 "fields": [
                   { "type": "mrkdwn", "text": "*Project:* ${{ github.event.repository.name }}" },
-                  { "type": "mrkdwn", "text": "*When:* ${{ steps.build-start-time.env.BUILD_START_TIME }}" },
+                  { "type": "mrkdwn", "text": "*When:* ${{ steps.build-start-time.env.BUILD_RUN_TIME }}" },
                   { "type": "mrkdwn", "text": "*Branch:* \n${{ github.ref_name }}" },
                   { "type": "mrkdwn", "text": "*Successful Job:* \n${{ github.job }}" }
                 ]

--- a/.github/actions/slack-notify-composite-action/action.yml
+++ b/.github/actions/slack-notify-composite-action/action.yml
@@ -39,6 +39,17 @@ runs:
                 ]
               },
               {
+                "type": "actions",
+                "elements": [
+                  {
+                    "type": "button",
+                    "action_id": "deployment_link",
+                    "text": { "type": "plain_text", "text": "View Run" },
+                    "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  }
+                ]
+              },
+              {
                 "type": "section",
                 "fields": [
                   {

--- a/.github/actions/slack-notify-composite-action/action.yml
+++ b/.github/actions/slack-notify-composite-action/action.yml
@@ -40,7 +40,7 @@ runs:
                   { "type": "mrkdwn", "text": "*Project:* ${{ github.event.repository.name }}" },
                   { "type": "mrkdwn", "text": "*When:* ${{ env.BUILD_START_TIME }}" },
                   { "type": "mrkdwn", "text": "*Branch:* \n${{ github.ref_name }}" },
-                  { "type": "mrkdwn", "text": "*Successful Job:* \n${{ github.job }}" } ${{ steps}}
+                  { "type": "mrkdwn", "text": "*Successful Job:* \n${{ github.job }}" }
                 ]
               },
               {

--- a/.github/actions/slack-notify-composite-action/action.yml
+++ b/.github/actions/slack-notify-composite-action/action.yml
@@ -1,16 +1,19 @@
 name: Slack channel notification
-description: 'Send notification to Slack channel'
+description: "Send notification to Slack channel"
 
 inputs:
   slack-channel:
-    description: 'The name of the Slack channel to which notifications will be sent. Default - laa-crimeapps-ci'
+    description: "The name of the Slack channel to which notifications will be sent. Default - laa-crimeapps-ci"
     required: false
-    default: 'laa-crimeapps-ci'
+    default: "laa-crimeapps-ci"
+  webhook-url:
+    description: "The webhook URL of the Slack channel."
+    required: true
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
-    - id: Notify success to Slack
+    - name: Notify success to Slack
       if: ${{ success() }}
       uses: slackapi/slack-github-action@v1
       with:
@@ -48,9 +51,9 @@ runs:
             ]
           }
       env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        SLACK_WEBHOOK_URL: ${{ inputs.webhook-url }}
 
-    - id: Notify failure to Slack (non-main branches only)
+    - name: Notify failure to Slack (non-main branches only)
       if: ${{ failure() && github.ref_name != 'main' }}
       uses: 8398a7/action-slack@v3
       with:
@@ -64,4 +67,4 @@ runs:
           *Actor:* ${{ github.actor }}  
           *Run:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
       env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        SLACK_WEBHOOK_URL: ${{ inputs.webhook-url }}

--- a/.github/actions/slack-notify-composite-action/action.yml
+++ b/.github/actions/slack-notify-composite-action/action.yml
@@ -22,11 +22,21 @@ runs:
           {
             "blocks": [
               {
-                "type": "section",
+                "type": "header",
                 "text": {
-                  "type": "mrkdwn",
-                  "text": "*:white_check_mark: Succeeded GitHub Actions*"
+                  "type": "plain_text",
+                  "text": "Deployment Successful! :partying_face:"
+                  "emoji": true
                 }
+              },
+              {
+                "type": "section",
+                "fields": [
+                  { "type": "mrkdwn", "text": "*Project:* ${{ github.event.repository.name }}" },
+                  { "type": "mrkdwn", "text": "*When:* ${{ github.run_started_at }}" },
+                  { "type": "mrkdwn", "text": "*Branch:* \n${{ github.ref_name }}" },
+                  { "type": "mrkdwn", "text": "*Successful Job:* \n${{ github.job }}" }
+                ]
               },
               {
                 "type": "section",

--- a/.github/actions/slack-notify-composite-action/action.yml
+++ b/.github/actions/slack-notify-composite-action/action.yml
@@ -1,0 +1,67 @@
+name: Slack channel notification
+description: 'Send notification to Slack channel'
+
+inputs:
+  slack-channel:
+    description: 'The name of the Slack channel to which notifications will be sent. Default - laa-crimeapps-ci'
+    required: false
+    default: 'laa-crimeapps-ci'
+
+runs:
+  using: 'composite'
+  steps:
+    - id: Notify success to Slack
+      if: ${{ success() }}
+      uses: slackapi/slack-github-action@v1
+      with:
+        payload: |
+          {
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": "Deployment Successful! :partying_face:",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "fields": [
+                  { "type": "mrkdwn", "text": "*Project:* ${{ github.event.repository.name }}" },
+                  { "type": "mrkdwn", "text": "*When:* ${{ github.run_started_at }}" },
+                  { "type": "mrkdwn", "text": "*Branch:* \n${{ github.ref_name }}" },
+                  { "type": "mrkdwn", "text": "*Successful Job:* \n${{ github.job }}" }
+                ]
+              },
+              {
+                "type": "actions",
+                "elements": [
+                  {
+                    "type": "button",
+                    "action_id": "deployment_link",
+                    "text": { "type": "plain_text", "text": "View Run" },
+                    "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  }
+                ]
+              }
+            ]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+    - id: Notify failure to Slack (non-main branches only)
+      if: ${{ failure() && github.ref_name != 'main' }}
+      uses: 8398a7/action-slack@v3
+      with:
+        status: ${{ job.status }}
+        fields: repo,commit,author,ref,workflow,job,took
+        text: |
+          :x: Deployment failed in *${{ github.workflow }}*  
+          *Repo:* ${{ github.repository }}  
+          *Branch:* ${{ github.ref_name }}  
+          *Job:* ${{ github.job }}  
+          *Actor:* ${{ github.actor }}  
+          *Run:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/actions/slack-notify-composite-action/action.yml
+++ b/.github/actions/slack-notify-composite-action/action.yml
@@ -39,7 +39,7 @@ runs:
                 "type": "section",
                 "fields": [
                   { "type": "mrkdwn", "text": "*Project:* ${{ github.event.repository.name }}" },
-                  { "type": "mrkdwn", "text": "*When:* ${{ steps.build-start-time.outputs.BUILD_RUN_TIME }}" },
+                  { "type": "mrkdwn", "text": "*When:* ${{ steps.build-run-time.outputs.BUILD_RUN_TIME }}" },
                   { "type": "mrkdwn", "text": "*Branch:* \n${{ github.ref_name }}" },
                   { "type": "mrkdwn", "text": "*Successful Job:* \n${{ github.job }}" }
                 ]

--- a/.github/actions/slack-notify-composite-action/action.yml
+++ b/.github/actions/slack-notify-composite-action/action.yml
@@ -16,7 +16,8 @@ runs:
     - name: Calculate build start time
       id: build-start-time
       shell: bash
-      run: echo "BUILD_START_TIME=$(date +%s)" >> $GITHUB_ENV
+      run: |
+        echo "BUILD_START_TIME=$(date +%s)" >> $GITHUB_ENV
 
     - name: Notify success to Slack
       id: slack-success
@@ -38,7 +39,7 @@ runs:
                 "type": "section",
                 "fields": [
                   { "type": "mrkdwn", "text": "*Project:* ${{ github.event.repository.name }}" },
-                  { "type": "mrkdwn", "text": "*When:* ${{ github.env.BUILD_START_TIME }}" },
+                  { "type": "mrkdwn", "text": "*When:* ${{ BUILD_START_TIME }}" },
                   { "type": "mrkdwn", "text": "*Branch:* \n${{ github.ref_name }}" },
                   { "type": "mrkdwn", "text": "*Successful Job:* \n${{ github.job }}" }
                 ]

--- a/.github/actions/slack-notify-composite-action/action.yml
+++ b/.github/actions/slack-notify-composite-action/action.yml
@@ -25,7 +25,7 @@ runs:
                 "type": "header",
                 "text": {
                   "type": "plain_text",
-                  "text": "Deployment Successful! :partying_face:"
+                  "text": "Deployment Successful! :partying_face:",
                   "emoji": true
                 }
               },

--- a/.github/actions/slack-notify-composite-action/action.yml
+++ b/.github/actions/slack-notify-composite-action/action.yml
@@ -17,7 +17,7 @@ runs:
       id: build-run-time
       shell: bash
       run: |
-        echo "BUILD_RUN_TIME=$(date +'%m/%d/%Y %T')" >> $GITHUB_ENV
+        echo "BUILD_RUN_TIME=$(date +'%m/%d/%Y %T')" >> $GITHUB_OUTPUT
 
     - name: Notify success to Slack
       id: slack-success
@@ -39,7 +39,7 @@ runs:
                 "type": "section",
                 "fields": [
                   { "type": "mrkdwn", "text": "*Project:* ${{ github.event.repository.name }}" },
-                  { "type": "mrkdwn", "text": "*When:* ${{ steps.build-start-time.env.BUILD_RUN_TIME }}" },
+                  { "type": "mrkdwn", "text": "*When:* ${{ steps.build-start-time.outputs.BUILD_RUN_TIME }}" },
                   { "type": "mrkdwn", "text": "*Branch:* \n${{ github.ref_name }}" },
                   { "type": "mrkdwn", "text": "*Successful Job:* \n${{ github.job }}" }
                 ]

--- a/.github/actions/slack-notify-composite-action/action.yml
+++ b/.github/actions/slack-notify-composite-action/action.yml
@@ -13,6 +13,11 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Calculate build start time
+      id: build-start-time
+      shell: bash
+      run: echo "BUILD_START_TIME=$(date +%s)" >> $GITHUB_ENV
+
     - name: Notify success to Slack
       id: slack-success
       if: ${{ success() }}
@@ -33,9 +38,9 @@ runs:
                 "type": "section",
                 "fields": [
                   { "type": "mrkdwn", "text": "*Project:* ${{ github.event.repository.name }}" },
-                  { "type": "mrkdwn", "text": "*When:* ${{ github.run_started_at }}" },
+                  { "type": "mrkdwn", "text": "*When:* ${{ env.BUILD_START_TIME }}" },
                   { "type": "mrkdwn", "text": "*Branch:* \n${{ github.ref_name }}" },
-                  { "type": "mrkdwn", "text": "*Successful Job:* \n${{ github.job }}" }
+                  { "type": "mrkdwn", "text": "*Successful Job:* \n${{ github.job }}" } ${{ steps}}
                 ]
               },
               {
@@ -45,48 +50,7 @@ runs:
                     "type": "button",
                     "action_id": "deployment_link",
                     "text": { "type": "plain_text", "text": "View Run" },
-                    "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                  }
-                ]
-              },
-              {
-                "type": "section",
-                "fields": [
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Repo*\n<https://github.com/${{ github.repository }}|${{ github.repository }}>"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Commit*\n<${{ github.event.head_commit.url }}|${{ env.SHORT_SHA }}>"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Author*\n${{ github.event.head_commit.author.name }}"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Job*\n`${{ github.job }}`"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Event Name*\n`${{ github.event_name }}`"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Workflow*\n`${{ github.workflow }}`"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Build Logs*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Took*\n`${{ steps.calculate_duration.outputs.duration }} sec`"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Message*\n${{ github.event.head_commit.message }}"
+                    "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   }
                 ]
               }

--- a/.github/actions/slack-notify-composite-action/action.yml
+++ b/.github/actions/slack-notify-composite-action/action.yml
@@ -39,7 +39,7 @@ runs:
                 "type": "section",
                 "fields": [
                   { "type": "mrkdwn", "text": "*Project:* ${{ github.event.repository.name }}" },
-                  { "type": "mrkdwn", "text": "*When:* ${{ BUILD_START_TIME }}" },
+                  { "type": "mrkdwn", "text": "*When:* ${{ steps.build-start-time.env.BUILD_START_TIME }}" },
                   { "type": "mrkdwn", "text": "*Branch:* \n${{ github.ref_name }}" },
                   { "type": "mrkdwn", "text": "*Successful Job:* \n${{ github.job }}" }
                 ]

--- a/.github/workflows/cp-deployment-branch.yml
+++ b/.github/workflows/cp-deployment-branch.yml
@@ -70,6 +70,8 @@ jobs:
 
       - name: Notify Slack channel
         uses: ./.github/actions/slack-notify-composite-action
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   deploy-to-test:
     name: deploy-to-test
@@ -100,6 +102,8 @@ jobs:
 
       - name: Notify Slack channel
         uses: ./.github/actions/slack-notify-composite-action
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   deploy-to-uat:
     name: deploy-to-uat
@@ -130,3 +134,5 @@ jobs:
 
       - name: Notify Slack channel
         uses: ./.github/actions/slack-notify-composite-action
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/cp-deployment-branch.yml
+++ b/.github/workflows/cp-deployment-branch.yml
@@ -68,61 +68,8 @@ jobs:
         env:
           GITHUB_TAG: ${{ github.sha }}
 
-      - name: Notify Slack (success only)
-        if: ${{ success() }}
-        uses: slackapi/slack-github-action@v1
-        with:
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "Deployment Successful! :partying_face:",
-                    "emoji": true
-                  }
-                },
-                {
-                  "type": "section",
-                  "fields": [
-                    { "type": "mrkdwn", "text": "*Project:* ${{ github.event.repository.name }}" },
-                    { "type": "mrkdwn", "text": "*When:* ${{ github.run_started_at }}" },
-                    { "type": "mrkdwn", "text": "*Branch:* \n${{ github.ref_name }}" },
-                    { "type": "mrkdwn", "text": "*Successful Job:* \n${{ github.job }}" }
-                  ]
-                },
-                {
-                  "type": "actions",
-                  "elements": [
-                    {
-                      "type": "button",
-                      "action_id": "deployment_link",
-                      "text": { "type": "plain_text", "text": "View Run" },
-                      "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    }
-                  ]
-                }
-              ]
-            }
-        env:
-            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-      - name: Notify Slack on failure (main branch only)
-        if: ${{ failure() && github.ref_name == 'main' }}
-        uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,commit,author,ref,workflow,job,took
-          text: |
-            :x: Deployment failed in *${{ github.workflow }}*  
-            *Repo:* ${{ github.repository }}  
-            *Branch:* ${{ github.ref_name }}  
-            *Job:* ${{ github.job }}  
-            *Actor:* ${{ github.actor }}  
-            *Run:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: Notify Slack channel
+        uses: ./.github/actions/slack-notify-composite-action
 
   deploy-to-test:
     name: deploy-to-test
@@ -151,61 +98,8 @@ jobs:
         env:
           GITHUB_TAG: ${{ github.sha }}
 
-      - name: Notify Slack (success only)
-        if: ${{ success() }} # CircleCI's `event: pass`
-        uses: slackapi/slack-github-action@v1
-        with:
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "Deployment Successful! :partying_face:",
-                    "emoji": true
-                  }
-                },
-                {
-                  "type": "section",
-                  "fields": [
-                    { "type": "mrkdwn", "text": "*Project:* ${{ github.event.repository.name }}" },
-                    { "type": "mrkdwn", "text": "*When:* ${{ github.run_started_at }}" },
-                    { "type": "mrkdwn", "text": "*Branch:* \n${{ github.ref_name }}" },
-                    { "type": "mrkdwn", "text": "*Successful Job:* \n${{ github.job }}" }
-                  ]
-                },
-                {
-                  "type": "actions",
-                  "elements": [
-                    {
-                      "type": "button",
-                      "action_id": "deployment_link",
-                      "text": { "type": "plain_text", "text": "View Run" },
-                      "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    }
-                  ]
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-      - name: Notify Slack on failure (main branch only)
-        if: ${{ failure() && github.ref_name == 'main' }}
-        uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,commit,author,ref,workflow,job,took
-          text: |
-            :x: Deployment failed in *${{ github.workflow }}*  
-            *Repo:* ${{ github.repository }}  
-            *Branch:* ${{ github.ref_name }}  
-            *Job:* ${{ github.job }}  
-            *Actor:* ${{ github.actor }}  
-            *Run:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: Notify Slack channel
+        uses: ./.github/actions/slack-notify-composite-action
 
   deploy-to-uat:
     name: deploy-to-uat
@@ -234,58 +128,5 @@ jobs:
         env:
           GITHUB_TAG: ${{ github.sha }}
 
-      - name: Notify Slack (success only)
-        if: ${{ success() }} # CircleCI's `event: pass`
-        uses: slackapi/slack-github-action@v1
-        with:
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "Deployment Successful! :partying_face:",
-                    "emoji": true
-                  }
-                },
-                {
-                  "type": "section",
-                  "fields": [
-                    { "type": "mrkdwn", "text": "*Project:* ${{ github.event.repository.name }}" },
-                    { "type": "mrkdwn", "text": "*When:* ${{ github.run_started_at }}" },
-                    { "type": "mrkdwn", "text": "*Branch:* \n${{ github.ref_name }}" },
-                    { "type": "mrkdwn", "text": "*Successful Job:* \n${{ github.job }}" }
-                  ]
-                },
-                {
-                  "type": "actions",
-                  "elements": [
-                    {
-                      "type": "button",
-                      "action_id": "deployment_link",
-                      "text": { "type": "plain_text", "text": "View Run" },
-                      "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    }
-                  ]
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-      - name: Notify Slack on failure (main branch only)
-        if: ${{ failure() && github.ref_name == 'main' }}
-        uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,commit,author,ref,workflow,job,took
-          text: |
-            :x: Deployment failed in *${{ github.workflow }}*  
-            *Repo:* ${{ github.repository }}  
-            *Branch:* ${{ github.ref_name }}  
-            *Job:* ${{ github.job }}  
-            *Actor:* ${{ github.actor }}  
-            *Run:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: Notify Slack channel
+        uses: ./.github/actions/slack-notify-composite-action

--- a/.github/workflows/cp-deployment-branch.yml
+++ b/.github/workflows/cp-deployment-branch.yml
@@ -68,6 +68,62 @@ jobs:
         env:
           GITHUB_TAG: ${{ github.sha }}
 
+      - name: Notify Slack (success only)
+        if: ${{ success() }}
+        uses: slackapi/slack-github-action@v1
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "Deployment Successful! :partying_face:",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    { "type": "mrkdwn", "text": "*Project:* ${{ github.event.repository.name }}" },
+                    { "type": "mrkdwn", "text": "*When:* ${{ github.run_started_at }}" },
+                    { "type": "mrkdwn", "text": "*Branch:* \n${{ github.ref_name }}" },
+                    { "type": "mrkdwn", "text": "*Successful Job:* \n${{ github.job }}" }
+                  ]
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "action_id": "deployment_link",
+                      "text": { "type": "plain_text", "text": "View Run" },
+                      "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Notify Slack on failure (main branch only)
+        if: ${{ failure() && github.ref_name == 'main' }}
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,commit,author,ref,workflow,job,took
+          text: |
+            :x: Deployment failed in *${{ github.workflow }}*  
+            *Repo:* ${{ github.repository }}  
+            *Branch:* ${{ github.ref_name }}  
+            *Job:* ${{ github.job }}  
+            *Actor:* ${{ github.actor }}  
+            *Run:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
   deploy-to-test:
     name: deploy-to-test
     needs: [application-image-build]
@@ -95,6 +151,62 @@ jobs:
         env:
           GITHUB_TAG: ${{ github.sha }}
 
+      - name: Notify Slack (success only)
+        if: ${{ success() }} # CircleCI's `event: pass`
+        uses: slackapi/slack-github-action@v1
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "Deployment Successful! :partying_face:",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    { "type": "mrkdwn", "text": "*Project:* ${{ github.event.repository.name }}" },
+                    { "type": "mrkdwn", "text": "*When:* ${{ github.run_started_at }}" },
+                    { "type": "mrkdwn", "text": "*Branch:* \n${{ github.ref_name }}" },
+                    { "type": "mrkdwn", "text": "*Successful Job:* \n${{ github.job }}" }
+                  ]
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "action_id": "deployment_link",
+                      "text": { "type": "plain_text", "text": "View Run" },
+                      "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Notify Slack on failure (main branch only)
+        if: ${{ failure() && github.ref_name == 'main' }}
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,commit,author,ref,workflow,job,took
+          text: |
+            :x: Deployment failed in *${{ github.workflow }}*  
+            *Repo:* ${{ github.repository }}  
+            *Branch:* ${{ github.ref_name }}  
+            *Job:* ${{ github.job }}  
+            *Actor:* ${{ github.actor }}  
+            *Run:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
   deploy-to-uat:
     name: deploy-to-uat
     needs: [application-image-build]
@@ -121,3 +233,59 @@ jobs:
           helm upgrade laa-maat-scheduled-tasks -f values-uat.yaml . --install --wait --namespace=${KUBE_NAMESPACE} --set image.tag="$GITHUB_TAG"
         env:
           GITHUB_TAG: ${{ github.sha }}
+
+      - name: Notify Slack (success only)
+        if: ${{ success() }} # CircleCI's `event: pass`
+        uses: slackapi/slack-github-action@v1
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "Deployment Successful! :partying_face:",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    { "type": "mrkdwn", "text": "*Project:* ${{ github.event.repository.name }}" },
+                    { "type": "mrkdwn", "text": "*When:* ${{ github.run_started_at }}" },
+                    { "type": "mrkdwn", "text": "*Branch:* \n${{ github.ref_name }}" },
+                    { "type": "mrkdwn", "text": "*Successful Job:* \n${{ github.job }}" }
+                  ]
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "action_id": "deployment_link",
+                      "text": { "type": "plain_text", "text": "View Run" },
+                      "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Notify Slack on failure (main branch only)
+        if: ${{ failure() && github.ref_name == 'main' }}
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,commit,author,ref,workflow,job,took
+          text: |
+            :x: Deployment failed in *${{ github.workflow }}*  
+            *Repo:* ${{ github.repository }}  
+            *Branch:* ${{ github.ref_name }}  
+            *Job:* ${{ github.job }}  
+            *Actor:* ${{ github.actor }}  
+            *Run:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4410)

- Added a new webhook to the laa-maat-scheduled-tasks-alerts Slack app to send deployment alerts to the #laa-crimeapps-ci channel
- Added a new secret (SLACK_WEBHOOK_URL) to the laa-maat-scheduled-tasks GitHub repository
- Added steps to send success and failure alerts to the deployment jobs sections in cp-deployment-branch.yml

- ## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
