### PR TITLE
Fix compilation error in Xhibit controller

### DIFF
--- a/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/controller/XhibitBatchesScheduledTasksController.java
+++ b/maat-scheduled-tasks/src/main/java/uk/gov/justice/laa/maat/scheduled/tasks/controller/XhibitBatchesScheduledTasksController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.justice.laa.maat.scheduled.tasks.annotation.StandardApiResponse;
-import uk.gov.justice.laa.maat.scheduled.tasks.scheduler.XhibitBatchesScheduler;
+import uk.gov.justice.laa.maat.scheduled.tasks.xhibit.scheduler.XhibitBatchesScheduler;
 
 
 @Slf4j


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4466)

This PR fixes a compilation error in the
`XhibitBatchesScheduledTasksController` introduced as part of a recent refactor to move all Xhibit related code into a separate `xhibit` package.
